### PR TITLE
feat(button): derive hasIconOnly from icon and slots

### DIFF
--- a/src/components/Button/Button.Story.svelte
+++ b/src/components/Button/Button.Story.svelte
@@ -50,7 +50,7 @@
     {:else if story === 'inline'}
       <Button />
     {:else if story === 'icon-only buttons'}
-      <Button {...iconOnlyProps} hasIconOnly />
+      <Button {...iconOnlyProps} />
     {:else if story === 'set of buttons'}
       <div class={cx('--btn-set')}>
         <Button kind="secondary" {...setProps}>Secondary button</Button>

--- a/src/components/Button/Button.svelte
+++ b/src/components/Button/Button.svelte
@@ -11,7 +11,6 @@
   export let type = 'button';
   export let icon = undefined;
   export let iconDescription = undefined;
-  export let hasIconOnly = false;
   export let tooltipPosition = undefined;
   export let tooltipAlignment = undefined;
   export let style = undefined;
@@ -19,6 +18,7 @@
   import { getContext } from 'svelte';
   import { cx } from '../../lib';
 
+  const hasIconOnly = !!icon && !$$props.$$slots;
   const ctx = getContext('ComposedModal');
 
   let buttonRef = undefined;


### PR DESCRIPTION
Instead of explicitly defining hasIconOnly, its value can be inferred from a falsy icon prop and an empty slot.