### PR TITLE
chore: apply recommended eslint rules, bump carbon-icons-svelte

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,20 @@
 {
-  "parserOptions": { "ecmaVersion": 2019, "sourceType": "module" },
-  "env": { "es6": true, "browser": true },
+  "extends": "eslint:recommended",
+  "env": {
+    "es6": true,
+    "browser": true,
+    "jest": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2019,
+    "sourceType": "module"
+  },
   "plugins": ["svelte3"],
-  "overrides": [{ "files": ["**/*.svelte"], "processor": "svelte3/svelte3" }]
+  "overrides": [
+    {
+      "files": ["**/*.svelte"],
+      "processor": "svelte3/svelte3"
+    }
+  ],
+  "ignorePatterns": ["*.snap"]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "carbon-icons-svelte": "^10.8.0-rc.0",
+    "carbon-icons-svelte": "^10.8.1",
     "flatpickr": "^4.6.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
     "carbon-icons-svelte": "^10.8.0-rc.0",
     "flatpickr": "^4.6.3"
   },
-  "peerDependencies": {
-    "carbon-components": "^10.8.0",
-    "carbon-icons-svelte": "^10.8.0-rc.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.7.4",

--- a/src/components/Breadcrumb/Breadcrumb.test.js
+++ b/src/components/Breadcrumb/Breadcrumb.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import Component from './Breadcrumb.Story.svelte';
 
 describe('Breadcrumb', () => {

--- a/src/components/Button/Button.Story.svelte
+++ b/src/components/Button/Button.Story.svelte
@@ -11,7 +11,6 @@
     kind,
     disabled,
     size,
-    renderIcon,
     iconDescription,
     small,
     tooltipPosition,

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -3,8 +3,6 @@ import Component from './Button.Story.svelte';
 
 export default { title: 'Button', decorators: [withKnobs] };
 
-// TODO: add selectable renderIcon for Default, Icon-only stories
-
 const kinds = {
   'Primary button (primary)': 'primary',
   'Secondary button (secondary)': 'secondary',

--- a/src/components/ComposedModal/ComposedModal.svelte
+++ b/src/components/ComposedModal/ComposedModal.svelte
@@ -9,7 +9,6 @@
   export let style = undefined;
 
   import { createEventDispatcher, tick, setContext, onMount, afterUpdate } from 'svelte';
-  import { writable } from 'svelte/store';
   import { cx } from '../../lib';
 
   const dispatch = createEventDispatcher();

--- a/src/components/ContentSwitcher/ContentSwitcher.Story.svelte
+++ b/src/components/ContentSwitcher/ContentSwitcher.Story.svelte
@@ -4,17 +4,26 @@
   import Layout from '../../internal/ui/Layout.svelte';
   import ContentSwitcher from './ContentSwitcher.svelte';
   import Switch from './Switch.svelte';
+
+  let selectedIndex = 0;
 </script>
 
 <Layout>
   {#if story === 'selected'}
-    <ContentSwitcher>
+    <ContentSwitcher
+      on:change={({ detail }) => {
+        console.log('on:change', detail);
+      }}>
       <Switch {...$$props} text="First section" />
       <Switch {...$$props} text="Second section" selected />
       <Switch {...$$props} text="Third section" />
     </ContentSwitcher>
   {:else}
-    <ContentSwitcher>
+    <ContentSwitcher
+      bind:selectedIndex
+      on:change={({ detail }) => {
+        console.log('on:change', detail);
+      }}>
       <Switch {...$$props} text="First section" />
       <Switch {...$$props} text="Second section" />
       <Switch {...$$props} text="Third section" />

--- a/src/components/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/components/ContentSwitcher/ContentSwitcher.svelte
@@ -39,12 +39,9 @@
   });
 
   $: if (switches[currentIndex]) {
+    dispatch('change', currentIndex);
     selectedIndex = currentIndex;
     currentId.set(switches[currentIndex].id);
-    switches = switches.map((_, i) => ({ ..._, selected: i === currentIndex }));
-
-    const { id, ...rest } = switches[currentIndex];
-    dispatch('change', { ...rest, index: currentIndex });
   }
 </script>
 

--- a/src/components/DatePicker/DatePicker.svelte
+++ b/src/components/DatePicker/DatePicker.svelte
@@ -22,7 +22,6 @@
 
   let inputs = writable([]);
   let inputIds = derived(inputs, _ => _.map(({ id }) => id));
-  let inputsById = derived(inputs, _ => _.reduce((a, c) => ({ ...a, [c.id]: c }), {}));
   let labelTextEmpty = derived(inputs, _ => _.filter(({ labelText }) => !!labelText).length === 0);
   let inputValue = writable(value);
   let mode = writable(datePickerType);
@@ -48,7 +47,7 @@
         inputRefTo = ref;
       }
     },
-    updateValue: ({ id, type, value }) => {
+    updateValue: ({ type, value }) => {
       if ((!calendar && type === 'input') || type === 'change') {
         inputValue.set(value);
       }

--- a/src/components/DatePicker/DatePickerInput.svelte
+++ b/src/components/DatePicker/DatePickerInput.svelte
@@ -30,7 +30,6 @@
   } = getContext('DatePicker');
 
   let inputRef = undefined;
-  let iconRef = undefined;
 
   add({ id, labelText });
 
@@ -56,10 +55,10 @@
       class={cx('--date-picker__input')}
       on:input
       on:input={({ target }) => {
-        updateValue({ id, type: 'input', value: target.value });
+        updateValue({ type: 'input', value: target.value });
       }}
       on:change={({ target }) => {
-        updateValue({ id, type: 'change', value: target.value });
+        updateValue({ type: 'change', value: target.value });
       }}
       on:keydown
       on:keydown={({ key }) => {

--- a/src/components/DatePicker/flatpickr.js
+++ b/src/components/DatePicker/flatpickr.js
@@ -65,10 +65,10 @@ function createCalendar({ options, base, input, dispatch }) {
     onClose: () => {
       dispatch('close');
     },
-    onMonthChange: ({}, {}, instance) => {
+    onMonthChange: (s, d, instance) => {
       updateMonthNode(instance);
     },
-    onOpen: ({}, {}, instance) => {
+    onOpen: (s, d, instance) => {
       dispatch('open');
       updateClasses(instance);
       updateMonthNode(instance);

--- a/src/components/FileUploader/FileUploader.svelte
+++ b/src/components/FileUploader/FileUploader.svelte
@@ -64,7 +64,7 @@
               }
             }}
             on:click
-            on:click={evt => {
+            on:click={() => {
               files = files.filter((_, index) => index !== i);
             }}
             {iconDescription}

--- a/src/components/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/components/FileUploader/FileUploaderDropContainer.svelte
@@ -13,8 +13,6 @@
   export let style = undefined;
 
   import { createEventDispatcher } from 'svelte';
-  import SkeletonText from '../SkeletonText';
-  import { ButtonSkeleton } from '../Button';
   import { cx } from '../../lib';
 
   const dispatch = createEventDispatcher();

--- a/src/components/FileUploader/Filename.svelte
+++ b/src/components/FileUploader/Filename.svelte
@@ -22,7 +22,6 @@
   {#if invalid}
     <WarningFilled16 class={cx('--file-invalid')} />
   {/if}
-  <!-- TODO: forward keydown event to Svelte icon -->
   <Close16
     class={cx('--file-close', className)}
     aria-label={iconDescription}

--- a/src/components/Modal/Modal.svelte
+++ b/src/components/Modal/Modal.svelte
@@ -6,6 +6,7 @@
   export let id = Math.random();
   export let modalHeading = undefined;
   export let modalLabel = undefined;
+  export let modalAriaLabel = undefined;
   export let open = false;
   export let iconDescription = 'Close the modal';
   export let primaryButtonDisabled = false;
@@ -19,7 +20,6 @@
   export let style = undefined;
 
   import { createEventDispatcher, afterUpdate, onDestroy } from 'svelte';
-  import { writable } from 'svelte/store';
   import Close20 from 'carbon-icons-svelte/lib/Close20';
   import { cx } from '../../lib';
   import Button from '../Button';

--- a/src/components/OverflowMenu/OverflowMenu.svelte
+++ b/src/components/OverflowMenu/OverflowMenu.svelte
@@ -14,7 +14,7 @@
   export let style = undefined;
 
   import { createEventDispatcher, setContext, afterUpdate } from 'svelte';
-  import { writable, derived } from 'svelte/store';
+  import { writable } from 'svelte/store';
   import OverflowMenuVertical16 from 'carbon-icons-svelte/lib/OverflowMenuVertical16';
   import { cx } from '../../lib';
   import { formatStyle } from './formatStyle';

--- a/src/components/ProgressIndicator/ProgressIndicator.stories.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.stories.js
@@ -1,4 +1,4 @@
-import { withKnobs, boolean, text, number } from '@storybook/addon-knobs';
+import { withKnobs, boolean, number } from '@storybook/addon-knobs';
 import Component from './ProgressIndicator.Story.svelte';
 
 export default { title: 'ProgressIndicator', decorators: [withKnobs] };

--- a/src/components/ProgressIndicator/ProgressStep.svelte
+++ b/src/components/ProgressIndicator/ProgressStep.svelte
@@ -10,12 +10,11 @@
   export let disabled = false;
   export let style = undefined;
 
-  import { createEventDispatcher, getContext } from 'svelte';
+  import { getContext } from 'svelte';
   import Warning16 from 'carbon-icons-svelte/lib/Warning16';
   import CheckmarkOutline16 from 'carbon-icons-svelte/lib/CheckmarkOutline16';
   import { cx } from '../../lib';
 
-  const dispatch = createEventDispatcher();
   const id = Math.random();
   const { stepsById, add, change } = getContext('ProgressIndicator');
 

--- a/src/components/RadioButton/RadioButton.Story.svelte
+++ b/src/components/RadioButton/RadioButton.Story.svelte
@@ -2,7 +2,6 @@
   export let story = undefined;
 
   import Layout from '../../internal/ui/Layout.svelte';
-  import ListItem from '../ListItem';
   import RadioButton from './RadioButton.svelte';
   import RadioButtonSkeleton from './RadioButton.Skeleton.svelte';
 </script>

--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -3,11 +3,6 @@ import Component from './Select.Story.svelte';
 
 export default { title: 'Select', decorators: [withKnobs] };
 
-const labelPositions = {
-  'Left (left)': 'left',
-  'Right (right)': 'right'
-};
-
 export const Default = () => ({
   Component,
   props: {
@@ -32,5 +27,8 @@ export const Default = () => ({
 
 export const Skeleton = () => ({
   Component,
-  props: { story: 'skeleton', hideLabel: boolean('No label (hideLabel in <Select>)', false) }
+  props: {
+    story: 'skeleton',
+    hideLabel: boolean('No label (hideLabel in <Select>)', false)
+  }
 });

--- a/src/components/Slider/Slider.svelte
+++ b/src/components/Slider/Slider.svelte
@@ -9,9 +9,8 @@
   export let minLabel = '';
   export let maxLabel = '';
   export let labelText = '';
-  export let formatLabel = (value, label) => {
-    return typeof label === 'function' ? label(value) : `${value}${label}`;
-  };
+  export let formatLabel = (value, label) =>
+    typeof label === 'function' ? label(value) : `${value}${label}`;
   export let step = 1;
   export let stepMultiplier = 4;
   export let disabled = false;
@@ -22,7 +21,7 @@
   export let light = false;
   export let style = undefined;
 
-  import { createEventDispatcher, afterUpdate, tick } from 'svelte';
+  import { createEventDispatcher, afterUpdate } from 'svelte';
   import { cx } from '../../lib';
 
   const dispatch = createEventDispatcher();

--- a/src/components/StructuredList/StructuredList.stories.js
+++ b/src/components/StructuredList/StructuredList.stories.js
@@ -1,4 +1,4 @@
-import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 import Component from './StructuredList.Story.svelte';
 
 export default { title: 'StructuredList', decorators: [withKnobs] };

--- a/src/components/Tile/ExpandableTile.svelte
+++ b/src/components/Tile/ExpandableTile.svelte
@@ -13,7 +13,7 @@
 
   import { onMount, afterUpdate } from 'svelte';
   import ChevronDown16 from 'carbon-icons-svelte/lib/ChevronDown16';
-  import { cx, css } from '../../lib';
+  import { cx } from '../../lib';
 
   let tile = undefined;
   let tileContent = undefined;

--- a/src/components/Tile/Tile.stories.js
+++ b/src/components/Tile/Tile.stories.js
@@ -1,13 +1,11 @@
-import { withKnobs, select, number, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, number, boolean, text } from '@storybook/addon-knobs';
 import Component from './Tile.Story.svelte';
 
 export default { title: 'Tile', decorators: [withKnobs] };
 
 export const Default = () => ({
   Component,
-  props: {
-    light: boolean('Light variant (light)', false)
-  }
+  props: { light: boolean('Light variant (light)', false) }
 });
 
 export const Clickable = () => ({
@@ -27,13 +25,6 @@ export const MultiSelect = () => ({
     light: boolean('Light variant (light)', false)
   }
 });
-
-const radioValues = {
-  None: '',
-  standard: 'standard',
-  'default-selected': 'default-selected',
-  selected: 'selected'
-};
 
 export const Selectable = () => ({
   Component,

--- a/src/components/TimePicker/TimePicker.svelte
+++ b/src/components/TimePicker/TimePicker.svelte
@@ -15,10 +15,7 @@
   export let light = false;
   export let style = undefined;
 
-  import { createEventDispatcher } from 'svelte';
   import { cx } from '../../lib';
-
-  const dispatch = createEventDispatcher();
 </script>
 
 <div on:click on:mouseover on:mouseenter on:mouseleave class={cx('--form-item', className)} {style}>

--- a/src/lib/css.js
+++ b/src/lib/css.js
@@ -1,6 +1,6 @@
 function css(array) {
   return array
-    .map((item, i) => {
+    .map(item => {
       if (!item) return false;
 
       return Array.isArray(item)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,10 +3283,10 @@ carbon-components@10.9.0:
     lodash.debounce "^4.0.8"
     warning "^3.0.0"
 
-carbon-icons-svelte@^10.8.0-rc.0:
-  version "10.8.0-rc.0"
-  resolved "https://registry.npmjs.org/carbon-icons-svelte/-/carbon-icons-svelte-10.8.0-rc.0.tgz#1ea853c737a7f03d34f7a1a8171eaca97eaead12"
-  integrity sha512-g4Jwtu5VlXKzC2lOrnrmQXkcJRnM+if1fvxh5r71/0dm6cO5PUrXG0BDZLdVBjnSjEbxduTI2oWVukUCFnHtVA==
+carbon-icons-svelte@^10.8.1:
+  version "10.8.1"
+  resolved "https://registry.npmjs.org/carbon-icons-svelte/-/carbon-icons-svelte-10.8.1.tgz#b4fcf1fcda22ed17f7820211492e6100639d8e3c"
+  integrity sha512-1CST4qRV8lu49OYgHVBzj9VN03ipY6+qyZPSQGx+chK6Z9sn+NdJUNhR1mvPIgfddz5SY30RSR76Vfd22bQC9Q==
 
 carbon-icons@^7.0.7:
   version "7.0.7"


### PR DESCRIPTION
**Changes**

- remove `peerDependencies` field; strategy is to fold dependencies into `carbon-components-svelte`
- use eslint:recommended and apply new linting rules
- bump `carbon-icons-svelte` to 10.8.1, which includes support for forwarding the `keydown` event