### PR TITLE
fix(deps): upgrade carbon-icons-svelte to exclude focusring

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "carbon-icons-svelte": "^10.8.1",
+    "carbon-icons-svelte": "^10.8.2",
     "flatpickr": "^4.6.3"
   },
   "devDependencies": {

--- a/src/components/ListBox/ListBoxMenuIcon.svelte
+++ b/src/components/ListBox/ListBoxMenuIcon.svelte
@@ -21,5 +21,5 @@
   on:click|preventDefault|stopPropagation
   class={cx('--list-box__menu-icon', open && '--list-box__menu-icon--open', className)}
   {style}>
-  <ChevronDown16 name="chevron--down" tabindex="-1" aria-label={description} title={description} />
+  <ChevronDown16 aria-label={description} title={description} />
 </div>

--- a/src/components/ListBox/ListBoxSelection.svelte
+++ b/src/components/ListBox/ListBoxSelection.svelte
@@ -39,5 +39,5 @@
   }}
   {style}>
   {#if selectionCount}{selectionCount}{/if}
-  <Close16 focusable="false" tabindex="-1" />
+  <Close16 />
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,10 +3283,10 @@ carbon-components@10.9.0:
     lodash.debounce "^4.0.8"
     warning "^3.0.0"
 
-carbon-icons-svelte@^10.8.1:
-  version "10.8.1"
-  resolved "https://registry.npmjs.org/carbon-icons-svelte/-/carbon-icons-svelte-10.8.1.tgz#b4fcf1fcda22ed17f7820211492e6100639d8e3c"
-  integrity sha512-1CST4qRV8lu49OYgHVBzj9VN03ipY6+qyZPSQGx+chK6Z9sn+NdJUNhR1mvPIgfddz5SY30RSR76Vfd22bQC9Q==
+carbon-icons-svelte@^10.8.2:
+  version "10.8.2"
+  resolved "https://registry.npmjs.org/carbon-icons-svelte/-/carbon-icons-svelte-10.8.2.tgz#b1432c8de8a19210f50b42e1498b08d01c25b86b"
+  integrity sha512-5kPCxcED9OXV96NRFKqWbUGRfBf4qX0XcvYqV4c5IL8yGaJGWu1qows7ldENqhwVGXrfsBNQ7tDoR0fIC3CSsw==
 
 carbon-icons@^7.0.7:
   version "7.0.7"


### PR DESCRIPTION
Fixes #90 

**Changes**

- Bump `carbon-icons-svelte` to ^10.8.2
- Allow focus styles for icons in `ListBox` components