### PR TITLE
Fix window is undefined

### DIFF
--- a/src/components/UIShell/UIShell.svelte
+++ b/src/components/UIShell/UIShell.svelte
@@ -14,20 +14,24 @@
   import UIShellSideNavWrapper from './UIShellSideNav/UIShellSideNavWrapper.svelte';
   import UIShellSideNavItem from './UIShellSideNav/UIShellSideNavItem.svelte';
   import HamburgerMenu from './UIShellSideNav/HamburgerMenu.svelte';
-
+  import { onMount } from 'svelte' 
+  
   let isSideNavOpen = undefined;
-  let winWidth = window.innerWidth;
+  let winWidth = undefined;
+  
+  onMount(() => {
+    winWidth = window.innerWidth
+    window.addEventListener('resize', () => {
+      winWidth = window.innerWidth;
 
-  window.addEventListener('resize', () => {
-    winWidth = window.innerWidth;
-
-    if (winWidth >= 1056) {
-      isSideNavOpen = true;
-    } else {
-      isSideNavOpen = false;
-    }
-  });
-
+      if (winWidth >= 1056) {
+        isSideNavOpen = true;
+      } else {
+        isSideNavOpen = false;
+      }
+    });
+  })  
+  
   $: ariaLabel = company + (uiShellAriaLabel || $$props['aria-label'] || platformName);
 </script>
 

--- a/src/components/UIShell/UIShell.svelte
+++ b/src/components/UIShell/UIShell.svelte
@@ -18,22 +18,12 @@
   
   let isSideNavOpen = undefined;
   let winWidth = undefined;
-  
-  onMount(() => {
-    winWidth = window.innerWidth
-    window.addEventListener('resize', () => {
-      winWidth = window.innerWidth;
+  $: isSideNavOpen = winWidth >= 1056
 
-      if (winWidth >= 1056) {
-        isSideNavOpen = true;
-      } else {
-        isSideNavOpen = false;
-      }
-    });
-  })  
-  
   $: ariaLabel = company + (uiShellAriaLabel || $$props['aria-label'] || platformName);
 </script>
+
+<svelte:window bind:innerWidth={winWidth} />
 
 <header aria-label={ariaLabel} class={cx('--header')} role="banner">
   {#if winWidth < 1056}

--- a/src/components/UIShell/UIShell.svelte
+++ b/src/components/UIShell/UIShell.svelte
@@ -14,7 +14,6 @@
   import UIShellSideNavWrapper from './UIShellSideNav/UIShellSideNavWrapper.svelte';
   import UIShellSideNavItem from './UIShellSideNav/UIShellSideNavItem.svelte';
   import HamburgerMenu from './UIShellSideNav/HamburgerMenu.svelte';
-  import { onMount } from 'svelte' 
   
   let isSideNavOpen = undefined;
   let winWidth = undefined;


### PR DESCRIPTION
Moving global window access to onMount hook for to fix "window is undefined" error when using with sapper, etc.