### PR TITLE
Fix pagination component

### DIFF
--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -68,9 +68,6 @@
         labelText={`Page number, of ${totalPages} pages`}
         inline
         hideLabel
-        on:change={({ detail }) => {
-          page = Number(detail);
-        }}
         bind:defaultValue={page}>
         {#each selectItems as size, i (size)}
           <SelectItem value={size + 1} text={(size + 1).toString()} />

--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -47,7 +47,7 @@
       on:change={() => {
         page = 1;
       }}
-      bind:defaultValue={pageSize}>
+      bind:selected={pageSize}>
       {#each pageSizes as size, i (size)}
         <SelectItem value={size} text={size.toString()} />
       {/each}
@@ -68,7 +68,7 @@
         labelText={`Page number, of ${totalPages} pages`}
         inline
         hideLabel
-        bind:defaultValue={page}>
+        bind:selected={page}>
         {#each selectItems as size, i (size)}
           <SelectItem value={size + 1} text={(size + 1).toString()} />
         {/each}


### PR DESCRIPTION
The `Pagination` component had a naming error in the bound name for both `Select` components (One that changes the page size, the other changes the current page).
Because of this it would not display the correct values in the pager part of it due to this bug.

This PR fixes issue #178 by binding the correct variables.