### PR TITLE
Added Event Forwarding To Pagination Component

### DIFF
--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -22,6 +22,19 @@
   import CaretRight24 from 'carbon-icons-svelte/lib/CaretRight24';
   import { cx, fillArray } from '../../lib';
   import Select, { SelectItem } from '../Select';
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+  const handlePaginationChange = (type, value) => {
+      if (type === 'pageSize') {
+        page = 1;
+        pageSize = value;
+      } else {
+        page = value;
+      }
+
+      dispatch('update', {pageSize, page});
+  };  
 
   $: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
   $: selectItems = fillArray(totalPages);
@@ -43,9 +56,9 @@
       labelText=""
       hideLabel
       noLabel
-      inline
-      on:change={() => {
-        page = 1;
+      inline      
+      on:blur={() => {
+        handlePaginationChange('pageSize', pageSize);
       }}
       bind:selected={pageSize}>
       {#each pageSizes as size, i (size)}
@@ -68,6 +81,9 @@
         labelText={`Page number, of ${totalPages} pages`}
         inline
         hideLabel
+        on:blur={() => {
+          handlePaginationChange('page', page);          
+        }}
         bind:selected={page}>
         {#each selectItems as size, i (size)}
           <SelectItem value={size + 1} text={(size + 1).toString()} />
@@ -82,6 +98,7 @@
       class={cx('--pagination__button', '--pagination__button--backward', backButtonDisabled && '--pagination__button--no-index')}
       on:click={() => {
         page--;
+        handlePaginationChange('page', page);        
       }}
       aria-label={backwardText}
       disabled={backButtonDisabled}>
@@ -93,6 +110,7 @@
       aria-label={forwardText}
       on:click={() => {
         page++;
+        handlePaginationChange('page', page);        
       }}
       disabled={forwardButtonDisabled}>
       <CaretRight24 />

--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -28,7 +28,7 @@
 
   afterUpdate(() => {
     dispatch('update', {pageSize, page});
-	});
+  });
 
   $: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
   $: selectItems = fillArray(totalPages);

--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -53,7 +53,7 @@
       inline
       on:change={() => {
         page = 1;
-      }} 
+      }}
       bind:selected={pageSize}>
       {#each pageSizes as size, i (size)}
         <SelectItem value={size} text={size.toString()} />

--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -84,7 +84,7 @@
     <button
       type="button"
       class={cx('--pagination__button', '--pagination__button--backward', backButtonDisabled && '--pagination__button--no-index')}
-      on:click|capture={() => {
+      on:click={() => {
         page--;
       }}
       aria-label={backwardText}
@@ -95,7 +95,7 @@
       type="button"
       class={cx('--pagination__button', '--pagination__button--forward', forwardButtonDisabled && '--pagination__button--no-index')}
       aria-label={forwardText}
-      on:click|capture={() => {
+      on:click={() => {
         page++;
       }}
       disabled={forwardButtonDisabled}>

--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -17,24 +17,18 @@
   export let pageText = page => `page ${page}`;
   export let style = undefined;
   export let totalItems = 0;
-
+  
   import CaretLeft24 from 'carbon-icons-svelte/lib/CaretLeft24';
   import CaretRight24 from 'carbon-icons-svelte/lib/CaretRight24';
   import { cx, fillArray } from '../../lib';
   import Select, { SelectItem } from '../Select';
-  import { createEventDispatcher } from 'svelte';
+  import { afterUpdate, createEventDispatcher } from 'svelte';  
 
   const dispatch = createEventDispatcher();
-  const handlePaginationChange = (type, value) => {
-      if (type === 'pageSize') {
-        page = 1;
-        pageSize = value;
-      } else {
-        page = value;
-      }
 
-      dispatch('update', {pageSize, page});
-  };  
+  afterUpdate(() => {
+    dispatch('update', {pageSize, page});
+	});
 
   $: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
   $: selectItems = fillArray(totalPages);
@@ -57,9 +51,6 @@
       hideLabel
       noLabel
       inline      
-      on:blur={() => {
-        handlePaginationChange('pageSize', pageSize);
-      }}
       bind:selected={pageSize}>
       {#each pageSizes as size, i (size)}
         <SelectItem value={size} text={size.toString()} />
@@ -80,10 +71,7 @@
         class={cx('--select__page-number')}
         labelText={`Page number, of ${totalPages} pages`}
         inline
-        hideLabel
-        on:blur={() => {
-          handlePaginationChange('page', page);          
-        }}
+        hideLabel        
         bind:selected={page}>
         {#each selectItems as size, i (size)}
           <SelectItem value={size + 1} text={(size + 1).toString()} />
@@ -96,9 +84,8 @@
     <button
       type="button"
       class={cx('--pagination__button', '--pagination__button--backward', backButtonDisabled && '--pagination__button--no-index')}
-      on:click={() => {
-        page--;
-        handlePaginationChange('page', page);        
+      on:click|capture={() => {
+        page--;        
       }}
       aria-label={backwardText}
       disabled={backButtonDisabled}>
@@ -108,9 +95,8 @@
       type="button"
       class={cx('--pagination__button', '--pagination__button--forward', forwardButtonDisabled && '--pagination__button--no-index')}
       aria-label={forwardText}
-      on:click={() => {
-        page++;
-        handlePaginationChange('page', page);        
+      on:click|capture={() => {
+        page++;        
       }}
       disabled={forwardButtonDisabled}>
       <CaretRight24 />

--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -17,7 +17,7 @@
   export let pageText = page => `page ${page}`;
   export let style = undefined;
   export let totalItems = 0;
-  
+
   import CaretLeft24 from 'carbon-icons-svelte/lib/CaretLeft24';
   import CaretRight24 from 'carbon-icons-svelte/lib/CaretRight24';
   import { cx, fillArray } from '../../lib';
@@ -71,7 +71,7 @@
         class={cx('--select__page-number')}
         labelText={`Page number, of ${totalPages} pages`}
         inline
-        hideLabel        
+        hideLabel
         bind:selected={page}>
         {#each selectItems as size, i (size)}
           <SelectItem value={size + 1} text={(size + 1).toString()} />
@@ -85,7 +85,7 @@
       type="button"
       class={cx('--pagination__button', '--pagination__button--backward', backButtonDisabled && '--pagination__button--no-index')}
       on:click|capture={() => {
-        page--;        
+        page--;
       }}
       aria-label={backwardText}
       disabled={backButtonDisabled}>
@@ -96,7 +96,7 @@
       class={cx('--pagination__button', '--pagination__button--forward', forwardButtonDisabled && '--pagination__button--no-index')}
       aria-label={forwardText}
       on:click|capture={() => {
-        page++;        
+        page++;
       }}
       disabled={forwardButtonDisabled}>
       <CaretRight24 />

--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -50,7 +50,10 @@
       labelText=""
       hideLabel
       noLabel
-      inline      
+      inline
+      on:change={() => {
+        page = 1;
+      }} 
       bind:selected={pageSize}>
       {#each pageSizes as size, i (size)}
         <SelectItem value={size} text={size.toString()} />

--- a/src/components/Pagination/Pagination.svelte
+++ b/src/components/Pagination/Pagination.svelte
@@ -27,7 +27,7 @@
   const dispatch = createEventDispatcher();
 
   afterUpdate(() => {
-    dispatch('update', {pageSize, page});
+    dispatch('update', {pageSize: parseInt(pageSize), page: parseInt(page)});
   });
 
   $: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);


### PR DESCRIPTION
Added Event Forwarding to the Pagination component by adding handlers to the Next & Previous Page buttons and the Page Size and Page select fields.

These handlers will dispatch one event containing `page` and `pageSize` details.  This was done to prevent duplicate dispatches when the `pageSize` changes, as the `page` is always set to 1 when `pageSize` is changed.

Question: Is there a better way to handle select value changes than `onBlur`? Using `onChange` results in duplicate triggers since they are binded to the `page` and `pageSize` variables.