### PR TITLE
fix(overflow-menu): focus button after initial opening

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.svelte
+++ b/src/components/OverflowMenu/OverflowMenu.svelte
@@ -29,6 +29,7 @@
   let buttonRef = undefined;
   let buttonWidth = undefined;
   let menuRef = undefined;
+  let didOpen = false;
 
   setContext('OverflowMenu', {
     focusedId,
@@ -85,10 +86,15 @@
       }
     }
 
-    if (!open) {
+    if (didOpen && !open) {
       buttonRef.focus();
       items.set([]);
       currentId.set(undefined);
+      currentIndex.set(0);
+    }
+
+    if (!didOpen) {
+      didOpen = true;
     }
   });
 


### PR DESCRIPTION
#191

**Bug description**

The Overflow Menu button is focused, even without having been opened.

**Fix**

The fix focuses the button when closing the menu. Another change introduced resets the current menu item index (`currentIndex`) to 0 after closing.