### PR TITLE
fix(overflow-menu): set didOpen after menu opened

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.svelte
+++ b/src/components/OverflowMenu/OverflowMenu.svelte
@@ -93,7 +93,7 @@
       currentIndex.set(0);
     }
 
-    if (!didOpen) {
+    if (!didOpen && open) {
       didOpen = true;
     }
   });


### PR DESCRIPTION
#191

`didOpen` should only be true if the menu is opened for the first time.