### PR TITLE
feat(combo-box): dispatch select, clear events

### DIFF
--- a/src/ComboBox/ComboBox.Story.svelte
+++ b/src/ComboBox/ComboBox.Story.svelte
@@ -11,8 +11,8 @@
     {
       id: "option-4",
       text:
-        "An example option that is really long to show what should be done to handle long text"
-    }
+        "An example option that is really long to show what should be done to handle long text",
+    },
   ];
 
   $: toggled = false;
@@ -58,6 +58,12 @@
     bind:ref
     bind:value
     bind:selectedIndex
+    on:select={({ detail }) => {
+      console.log('on:select', detail);
+    }}
+    on:clear={() => {
+      console.log('on:clear');
+    }}
     {items}
     {shouldFilterItem} />
 </div>

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -233,7 +233,6 @@
             open = !open;
             if (highlightedIndex > -1 && highlightedIndex !== selectedIndex) {
               selectedIndex = highlightedIndex;
-              selectedId = items[selectedIndex].id;
               open = false;
             }
           } else if (key === 'Tab') {
@@ -287,7 +286,6 @@
             active={selectedIndex === i || selectedId === item.id}
             highlighted={highlightedIndex === i || selectedIndex === i}
             on:click={() => {
-              selectedId = item.id;
               selectedIndex = items
                 .map(({ id }) => id)
                 .indexOf(filteredItems[i].id);

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -111,7 +111,7 @@
    */
   export let ref = null;
 
-  import { afterUpdate } from "svelte";
+  import { createEventDispatcher, afterUpdate } from "svelte";
   import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16";
   import {
     ListBox,
@@ -121,6 +121,8 @@
     ListBoxMenuItem,
     ListBoxSelection,
   } from "../ListBox";
+
+  const dispatch = createEventDispatcher();
 
   let selectedId = undefined;
   let inputValue = "";
@@ -145,9 +147,18 @@
     } else {
       highlightedIndex = -1;
       inputValue = selectedItem ? selectedItem.text : "";
+
+      if (!selectedItem) {
+        selectedId = undefined;
+        selectedIndex = -1;
+      }
     }
   });
 
+  $: if (selectedIndex > -1) {
+    selectedId = items[selectedIndex].id;
+    dispatch("select", { selectedId, selectedIndex, selectedItem });
+  }
   $: ariaLabel = $$props["aria-label"] || "Choose an item";
   $: menuId = `menu-${id}`;
   $: comboId = `combo-${id}`;
@@ -222,6 +233,7 @@
             open = !open;
             if (highlightedIndex > -1 && highlightedIndex !== selectedIndex) {
               selectedIndex = highlightedIndex;
+              selectedId = items[selectedIndex].id;
               open = false;
             }
           } else if (key === 'Tab') {
@@ -250,6 +262,7 @@
       {/if}
       {#if inputValue}
         <ListBoxSelection
+          on:clear
           on:clear={() => {
             selectedIndex = -1;
             open = false;


### PR DESCRIPTION
#223 

---

**Changes**

- dispatch "select" event when selecting/changing a combo box item
- dispatch "clear" event when clearing the combo box (i.e. clicking the "x")
- also fixes a bug where the `selectedId` isn't reset when clearing the selection

**Usage**

```jsx
<ComboBox
    on:select={({ detail }) => {
      console.log('on:select', detail);
    }}
    on:clear={() => {
      console.log('on:clear');
    }}
    {items} />
```

`on:select` detail payload:

```ts
// e.detail
{
  selectedId: string;
  selectedItem: { id: string; text: string; };
  selectedIndex: number;
}
```