### PR TITLE
Fix InlineNotification and ToastNotification timeout

### DIFF
--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -53,7 +53,7 @@
    */
   export let iconDescription = "Closes notification";
 
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import NotificationIcon from "./NotificationIcon.svelte";
   import NotificationTextDetails from "./NotificationTextDetails.svelte";
   import NotificationButton from "./NotificationButton.svelte";
@@ -103,7 +103,7 @@
       <NotificationButton
         {iconDescription}
         {notificationType}
-        on:click={close()} />
+        on:click={close} />
     {/if}
   </div>
 {/if}

--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -18,6 +18,12 @@
   export let lowContrast = false;
 
   /**
+   * Set the timeout duration (ms) to hide the notification after opening it
+   * @type {number} [timeout=0]
+   */
+  export let timeout = 0;
+
+  /**
    * Set the `role` attribute
    * @type {string} [role="alert"]
    */
@@ -54,7 +60,23 @@
 
   const dispatch = createEventDispatcher();
 
-  $: open = true;
+  let open = true;
+  let timeoutId = undefined;
+
+  function close() {
+    open = false;
+    dispatch('close');
+  }
+
+  onMount(() => {
+    if (timeout) {
+      timeoutId = setTimeout(() => close(), timeout);
+    }
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  });
 </script>
 
 {#if open}
@@ -81,10 +103,7 @@
       <NotificationButton
         {iconDescription}
         {notificationType}
-        on:click={() => {
-          open = false;
-          dispatch('close');
-        }} />
+        on:click={close()} />
     {/if}
   </div>
 {/if}

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -18,7 +18,7 @@
   export let lowContrast = false;
 
   /**
-   * Set the timeout duration (ms) to hide the notification after closing it
+   * Set the timeout duration (ms) to hide the notification after opening it
    * @type {number} [timeout=0]
    */
   export let timeout = 0;
@@ -69,11 +69,14 @@
   let open = true;
   let timeoutId = undefined;
 
+  function close() {
+    open = false;
+    dispatch('close');
+  }
+
   onMount(() => {
     if (timeout) {
-      timeoutId = setTimeout(() => {
-        open = false;
-      }, timeout);
+      timeoutId = setTimeout(() => close(), timeout);
     }
 
     return () => {
@@ -102,10 +105,7 @@
       <NotificationButton
         {iconDescription}
         {notificationType}
-        on:click={() => {
-          open = false;
-          dispatch('close');
-        }} />
+        on:click={close()} />
     {/if}
   </div>
 {/if}

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -105,7 +105,7 @@
       <NotificationButton
         {iconDescription}
         {notificationType}
-        on:click={close()} />
+        on:click={close} />
     {/if}
   </div>
 {/if}


### PR DESCRIPTION
* Dispatch close event when a notification closes due to timeout

    This was my main issue I found when working with `ToastNotification` and `InlineNotification`. The `timeout` works, it hides the notification, but it never dispatches a `close`-event.
    Now with a `close`-event, we can attach handlers to that, and update components/sites/state according wether the notification got closed (either by a timeout or by the user).

* Fix documentation text on the timeout prop (its removing the notification after opening it, not after closing it)

    This was confusing. The documentation on the `timeout`-prop read: "Set the timeout duration (ms) to hide the notification after closing it". But the implementation was "closing the notification" after a given timeout "after opening it". So I decided to fix the documentation according to the implementation.

* Add `timeout` to `InlineNotification`. There is no reason why `InlineNotification` should not be able to disappear after a given timeout.