### PR TITLE
fix(dropdown): allow clicking chevron to toggle menu

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -275,7 +275,8 @@
           open="{open}" />
       {/if}
       <ListBoxMenuIcon
-        on:click="{() => {
+        on:click="{(e) => {
+          e.stopPropagation();
           open = !open;
         }}"
         translateWithId="{translateWithId}"

--- a/src/ListBox/ListBoxMenuIcon.svelte
+++ b/src/ListBox/ListBoxMenuIcon.svelte
@@ -36,6 +36,6 @@
   class:bx--list-box__menu-icon="{true}"
   class:bx--list-box__menu-icon--open="{open}"
   {...$$restProps}
-  on:click|preventDefault|stopPropagation>
+  on:click|preventDefault>
   <ChevronDown16 aria-label="{description}" title="{description}" />
 </div>

--- a/src/MultiSelect/MultiSelect.stories.js
+++ b/src/MultiSelect/MultiSelect.stories.js
@@ -20,7 +20,6 @@ export const Default = () => ({
     id: text("MultiSelect id", "multi-select-id"),
     name: text("MultiSelect name", "multi-select-name"),
     titleText: text("Title (titleText)", "Multiselect Title"),
-    helperText: text("Helper text (helperText)", "This is not helper text"),
     filterable: boolean("Filterable (filterable)", false),
     selectionFeedback: select(
       "Selection feedback (selectionFeedback)",

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -405,7 +405,8 @@
             open="{open}" />
         {/if}
         <ListBoxMenuIcon
-          on:click="{() => {
+          on:click="{(e) => {
+            e.stopPropagation();
             open = !open;
           }}"
           translateWithId="{translateWithId}"


### PR DESCRIPTION
#251

- fix(dropdown): allow propagation when clicking the chevron icon

---

This PR fixes a bug where clicking the chevron icon in the `Dropdown` component would not toggle the menu.

The solution is to remove the `stopPropagation` modifier in the `ListBoxMenuIcon` component.