### PR TITLE
fix(tile): add href prop

### DIFF
--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -10,6 +10,12 @@
    * @type {boolean} [light=false]
    */
   export let light = false;
+
+  /**
+   * Set the `href`
+   * @type {string} [href]
+   */
+  export let href = undefined;
 </script>
 
 <!-- svelte-ignore a11y-missing-attribute -->
@@ -19,6 +25,7 @@
   class:bx--tile--is-clicked="{clicked}"
   class:bx--tile--light="{light}"
   {...$$restProps}
+  href="{href}"
   on:click
   on:click="{() => {
     clicked = !clicked;


### PR DESCRIPTION
fixes #253 

## Description

adds `href` prop and JSDoc to `src/Tile/ClickableTile.svelte`