### PR TITLE
fix(link): remove visited styles by default

### DIFF
--- a/src/Link/Link.stories.js
+++ b/src/Link/Link.stories.js
@@ -9,5 +9,6 @@ export const Default = () => ({
     href: text("The link href (href)", "#"),
     inline: boolean("Use the in-line variant (inline)", false),
     disabled: boolean("Disabled (disabled)", false),
+    visited: boolean('Allow visited styles', false),
   },
 });

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -12,6 +12,12 @@
   export let disabled = false;
 
   /**
+   * Set to `true` to allow visited styles
+   * @type {boolean} [visited=false]
+   */
+  export let visited = false;
+
+  /**
    * Obtain a reference to the top-level HTML element
    * @type {null | HTMLAnchorElement | HTMLParagraphElement} [ref=null]
    */
@@ -24,6 +30,7 @@
     class:bx--link="{true}"
     class:bx--link--disabled="{disabled}"
     class:bx--link--inline="{inline}"
+    class:bx--link--visited="{visited}"
     {...$$restProps}
     on:click
     on:mouseover
@@ -38,6 +45,7 @@
     class:bx--link="{true}"
     class:bx--link--disabled="{disabled}"
     class:bx--link--inline="{inline}"
+    class:bx--link--visited="{visited}"
     rel="{$$restProps.target === '_blank' ? 'noopener noreferrer' : undefined}"
     {...$$restProps}
     on:click


### PR DESCRIPTION
fixes #258 

## Description

Adds boolean prop `visited` as defined in referenced commit with class toggles. Also updates story to include toggle