### PR TITLE
fix(TimePickerSelect): deprecate hideLabel to match spec

### DIFF
--- a/src/TimePicker/TimePicker.stories.js
+++ b/src/TimePicker/TimePicker.stories.js
@@ -36,7 +36,6 @@ export const Default = () => ({
     },
     select: {
       disabled: boolean("Disabled (disabled in <TimePickerSelect>)", false),
-      hideLabel: boolean("No label (hideLabel in <TimePickerSelect>)", true),
       labelText: text(
         "Label text (labelText in <TimePickerSelect>)",
         "Please select"

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -25,10 +25,10 @@
 
   /**
    * @deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.
-   * Set to `true` to visually hide the label text
-   * @type {boolean} [hideLabel=false]
+   * Set to `false` to show the label text
+   * @type {boolean} [hideLabel=true]
    */
-  export let hideLabel = false;
+  export let hideLabel = true;
 
   /**
    * Set an id for the select element

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -24,6 +24,7 @@
   export let labelText = "";
 
   /**
+   * @deprecated The `hideLabel` prop for `TimePickerSelect` is no longer needed and has been deprecated. It will be removed in the next major release.
    * Set to `true` to visually hide the label text
    * @type {boolean} [hideLabel=false]
    */
@@ -72,6 +73,7 @@
       for="{id}"
       class:bx--label="{true}"
       class:bx--visually-hidden="{hideLabel}">
+      <!-- TODO: set to always be `true` after `hideLabel` is deprecated -->
       {labelText}
     </label>
   {/if}


### PR DESCRIPTION
fixes #260 

## Description

Adds `@deprecated` JSDoc syntax with message from referenced commit. Also removes `hideLabel` option from TimePickerSelect story