### PR TITLE
fix(overflow-menu): focus menu button on escape key only

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -125,7 +125,6 @@
     }
 
     if (didOpen && !open) {
-      buttonRef.focus();
       items.set([]);
       currentId.set(undefined);
       currentIndex.set(0);
@@ -186,6 +185,7 @@
       } else if (e.key === 'Escape') {
         e.stopPropagation();
         open = false;
+        buttonRef.focus();
       }
     }
   }}">


### PR DESCRIPTION
Fixes #268

---

- fix(overflow-menu): focus menu button on escape key only