### PR TITLE
Fix slider

### DIFF
--- a/src/Slider/Slider.Story.svelte
+++ b/src/Slider/Slider.Story.svelte
@@ -4,7 +4,7 @@
   import Slider from "./Slider.svelte";
   import SliderSkeleton from "./Slider.Skeleton.svelte";
 
-  $: value = 50;
+  let value = 50;
 </script>
 
 {#if story === 'skeleton'}

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -1,9 +1,9 @@
 <script>
   /**
    * Specify the value of the slider
-   * @type {string} [value=""]
+   * @type {number} [value=0]
    */
-  export let value = "";
+  export let value = 0;
 
   /**
    * Set the maximum slider value
@@ -119,6 +119,13 @@
 
   function stopHolding() {
     holding = false;
+    dragging = false;
+  }
+
+  function move() {
+    if (holding) {
+      startDragging();
+    }
   }
 
   function calcValue(e) {
@@ -159,6 +166,13 @@
   }
 </script>
 
+<svelte:body
+  on:mousemove="{move}"
+  on:touchmove="{move}"
+  on:mouseup="{stopHolding}"
+  on:touchend="{stopHolding}"
+  on:touchcancel="{stopHolding}" />
+
 <div
   class:bx--form-item="{true}"
   {...$$restProps}
@@ -182,21 +196,15 @@
       tabindex="-1"
       class:bx--slider="{true}"
       class:bx--slider--disabled="{disabled}"
-      on:click="{startDragging}"
-      on:mousemove="{() => {
-        if (holding) {
-          startDragging();
+      on:mousedown="{startDragging}"
+      on:mousedown="{startHolding}"
+      on:touchstart="{startHolding}"
+      on:keydown="{({ shiftKey, key }) => {
+        const keys = { ArrowDown: -1, ArrowLeft: -1, ArrowRight: 1, ArrowUp: 1 };
+        if (keys[key]) {
+          value += step * (shiftKey ? range / step / stepMultiplier : 1) * keys[key];
         }
       }}"
-      on:touchmove="{() => {
-        if (holding) {
-          startDragging();
-        }
-      }}"
-      on:mouseup="{stopHolding}"
-      on:touchup="{stopHolding}"
-      on:touchend="{stopHolding}"
-      on:touchcancel="{stopHolding}"
     >
       <div
         role="slider"
@@ -206,14 +214,6 @@
         aria-valuemax="{max}"
         aria-valuemin="{min}"
         aria-valuenow="{value}"
-        on:mousedown="{startHolding}"
-        on:touchstart="{startHolding}"
-        on:keydown="{({ shiftKey, key }) => {
-          const keys = { ArrowDown: -1, ArrowLeft: -1, ArrowRight: 1, ArrowUp: 1 };
-          if (keys[key]) {
-            value += step * (shiftKey ? range / step / stepMultiplier : 1) * keys[key];
-          }
-        }}"
         id="{id}"
       ></div>
       <div bind:this="{trackRef}" class:bx--slider__track="{true}"></div>

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -101,7 +101,7 @@
    */
   export let ref = null;
 
-  import { createEventDispatcher, afterUpdate } from "svelte";
+  import { createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -144,12 +144,6 @@
     value = nextValue;
   }
 
-  afterUpdate(() => {
-    if (!holding) {
-      dispatch("change", value);
-    }
-  });
-
   $: range = max - min;
   $: left = ((value - min) / range) * 100;
   $: {
@@ -162,6 +156,10 @@
     if (dragging) {
       calcValue(event);
       dragging = false;
+    }
+
+    if (!holding) {
+      dispatch("change", value);
     }
   }
 </script>

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -129,6 +129,8 @@
   }
 
   function calcValue(e) {
+    if (disabled) return;
+
     const offsetX = e.touches ? e.touches[0].clientX : e.clientX;
     const { left, width } = trackRef.getBoundingClientRect();
     let nextValue =
@@ -158,7 +160,7 @@
       dragging = false;
     }
 
-    if (!holding) {
+    if (!holding && !disabled) {
       dispatch("change", value);
     }
   }


### PR DESCRIPTION
#288, #289

This PR addresses several defects in the Slider component.

**Fixes**

- mouse/touch movement should slide even if not hovering directly over the Slider UI (issue #288 )
- `value` prop should be a number, not a string (issue #289)
- dispatched "change" event should not occur when mounting
- slider should not update/dispatch events if `disabled` is set to `true`

**Breaking Changes**

- `value` prop is initialized as `0` instead of an empty string