### PR TITLE
feat(text-input): adds fluid variation of text input

### DIFF
--- a/src/FluidForm/FluidForm.Story.svelte
+++ b/src/FluidForm/FluidForm.Story.svelte
@@ -1,0 +1,38 @@
+<script>
+  import { PasswordInput, TextInput } from "../TextInput";
+  import FluidForm from "./FluidForm.svelte";
+
+  $: value = null;
+</script>
+
+<FluidForm
+  {...$$props}
+  on:submit="{(event) => {
+    console.log('on:submit', event);
+  }}"
+>
+  <TextInput
+    className="some-class"
+    id="test2"
+    labelText="Text Input label"
+    placeholder="Placeholder text"
+    bind:value
+    on:keydown="{(e) => {
+      console.log('on:keydown', e);
+    }}"
+    on:change="{() => {
+      console.log('change');
+    }}"
+  />
+  <PasswordInput
+    required
+    type="password"
+    id="test4"
+    labelText="Password"
+    invalid
+    invalidText="Your password must be at least 6 characters as well as contain at least one uppercase, one lowercase, and one number."
+    on:keydown="{(e) => {
+      console.log('on:keydown', e);
+    }}"
+  />
+</FluidForm>

--- a/src/FluidForm/FluidForm.Story.svelte
+++ b/src/FluidForm/FluidForm.Story.svelte
@@ -3,6 +3,9 @@
   import FluidForm from "./FluidForm.svelte";
 
   $: value = null;
+  // remove props on publish
+  export let inputInvalid = false;
+  export let passwordInvalid = false;
 </script>
 
 <FluidForm
@@ -17,6 +20,7 @@
     labelText="Text Input label"
     placeholder="Placeholder text"
     bind:value
+    invalid="{inputInvalid}"
     on:keydown="{(e) => {
       console.log('on:keydown', e);
     }}"
@@ -29,7 +33,7 @@
     type="password"
     id="test4"
     labelText="Password"
-    invalid
+    invalid="{passwordInvalid}"
     invalidText="Your password must be at least 6 characters as well as contain at least one uppercase, one lowercase, and one number."
     on:keydown="{(e) => {
       console.log('on:keydown', e);

--- a/src/FluidForm/FluidForm.Story.svelte
+++ b/src/FluidForm/FluidForm.Story.svelte
@@ -3,9 +3,6 @@
   import FluidForm from "./FluidForm.svelte";
 
   $: value = null;
-  // remove props on publish
-  export let inputInvalid = false;
-  export let passwordInvalid = false;
 </script>
 
 <FluidForm
@@ -20,7 +17,6 @@
     labelText="Text Input label"
     placeholder="Placeholder text"
     bind:value
-    invalid="{inputInvalid}"
     on:keydown="{(e) => {
       console.log('on:keydown', e);
     }}"
@@ -33,7 +29,7 @@
     type="password"
     id="test4"
     labelText="Password"
-    invalid="{passwordInvalid}"
+    invalid="{true}"
     invalidText="Your password must be at least 6 characters as well as contain at least one uppercase, one lowercase, and one number."
     on:keydown="{(e) => {
       console.log('on:keydown', e);

--- a/src/FluidForm/FluidForm.stories.js
+++ b/src/FluidForm/FluidForm.stories.js
@@ -1,8 +1,13 @@
-import { withKnobs } from "@storybook/addon-knobs";
+import { withKnobs, boolean } from "@storybook/addon-knobs";
 import Component from "./FluidForm.Story.svelte";
 
 export default { title: "FluidForm", decorators: [withKnobs] };
 
 export const Default = () => ({
   Component,
+  props: {
+    // remove props on publish
+    inputInvalid: boolean('input is invalid', false),
+    passwordInvalid: boolean('password is invalid', false)
+  }
 });

--- a/src/FluidForm/FluidForm.stories.js
+++ b/src/FluidForm/FluidForm.stories.js
@@ -5,9 +5,4 @@ export default { title: "FluidForm", decorators: [withKnobs] };
 
 export const Default = () => ({
   Component,
-  props: {
-    // remove props on publish
-    inputInvalid: boolean('input is invalid', false),
-    passwordInvalid: boolean('password is invalid', false)
-  }
 });

--- a/src/FluidForm/FluidForm.stories.js
+++ b/src/FluidForm/FluidForm.stories.js
@@ -1,0 +1,8 @@
+import { withKnobs } from "@storybook/addon-knobs";
+import Component from "./FluidForm.Story.svelte";
+
+export default { title: "FluidForm", decorators: [withKnobs] };
+
+export const Default = () => ({
+  Component,
+});

--- a/src/FluidForm/FluidForm.svelte
+++ b/src/FluidForm/FluidForm.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { setContext } from "svelte";
+  import { Form } from "../Form";
+
+  setContext("Form", {
+    isFluid: true,
+  });
+</script>
+
+<Form class="bx--form--fluid" {...$$restProps}>
+  <slot />
+</Form>

--- a/src/FluidForm/index.js
+++ b/src/FluidForm/index.js
@@ -1,0 +1,1 @@
+export { default as FluidForm } from './FluidForm.svelte'

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -107,17 +107,21 @@
    */
   export let ref = null;
 
+  import { getContext } from "svelte";
   import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16";
   import View16 from "carbon-icons-svelte/lib/View16";
   import ViewOff16 from "carbon-icons-svelte/lib/ViewOff16";
 
+  const ctx = getContext("Form");
+
+  $: isFluid = !!ctx && ctx.isFluid;
   $: errorId = `error-${id}`;
 </script>
 
 <div
   class:bx--form-item="{true}"
   class:bx--text-input-wrapper="{true}"
-  class:bx--password-input-wrapper="{true}"
+  class:bx--password-input-wrapper="{!isFluid}"
   {...$$restProps}
   on:click
   on:mouseover

--- a/src/TextInput/TextInput.Story.svelte
+++ b/src/TextInput/TextInput.Story.svelte
@@ -1,6 +1,7 @@
 <script>
   export let story = undefined;
 
+  import { FluidForm } from "../FluidForm";
   import PasswordInput from "./PasswordInput.svelte";
   import TextInput from "./TextInput.svelte";
   import TextInputSkeleton from "./TextInput.Skeleton.svelte";
@@ -54,6 +55,20 @@
       Hide password
     </button>
   </div>
+{:else if story === 'fluid'}
+  <FluidForm>
+    <TextInput
+      bind:ref
+      {...$$props}
+      bind:value
+      on:keydown="{(e) => {
+        console.log('on:keydown', e);
+      }}"
+      on:change="{() => {
+        console.log('change');
+      }}"
+    />
+  </FluidForm>
 {:else}
   <TextInput
     bind:ref

--- a/src/TextInput/TextInput.stories.js
+++ b/src/TextInput/TextInput.stories.js
@@ -35,6 +35,33 @@ export const Default = () => ({
   },
 });
 
+export const Fluid = () => ({
+  Component,
+  props: {
+    story: 'fluid',
+    size: select("Field size (size)", sizes, undefined) || undefined,
+    disabled: boolean("Disabled (disabled)", false),
+    light: boolean("Light variant (light)", false),
+    hideLabel: boolean("No label (hideLabel)", false),
+    labelText: text("Label text (labelText)", "Text Input label"),
+    helperText: text("Helper text (helperText)", "Optional helper text here"),
+    invalid: boolean("Show form validation UI (invalid)", false),
+    invalidText: text(
+      "Content of form validation UI (invalidText)",
+      "A valid value is required"
+    ),
+    warn: boolean("Show warning state (warn)", false),
+    warnText: text(
+      "Warning state text (warnText)",
+      "This will overwrite your current settings"
+    ),
+    placeholder: text("Placeholder text (placeholder)", "Placeholder text."),
+    inline: boolean("Inline variant (inline)", false),
+    id: text("TextInput id", "text-input-id"),
+    name: text("TextInput name", "text-input-name"),
+  },
+});
+
 export const TogglePasswordVisibility = () => ({
   Component,
   props: {

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -211,7 +211,7 @@
         on:blur
       />
       {#if isFluid}
-        <hr className="bx--text-input__divider" />
+        <hr class:bx--text-input__divider="{true}" />
       {/if}
       {#if isFluid && !inline && invalid}
         <div class:bx--form-requirement="{true}" id="{errorId}">

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -107,9 +107,13 @@
    */
   export let inline = false;
 
+  import { getContext } from "svelte";
   import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16";
   import WarningAltFilled16 from "carbon-icons-svelte/lib/WarningAltFilled16";
 
+  const ctx = getContext("Form");
+
+  $: isFluid = !!ctx && ctx.isFluid;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
 </script>
@@ -138,7 +142,7 @@
           {labelText}
         </label>
       {/if}
-      {#if helperText}
+      {#if !isFluid && helperText}
         <div
           class:bx--form__helper-text="{true}"
           class:bx--form__helper-text--disabled="{disabled}"
@@ -206,8 +210,19 @@
         on:focus
         on:blur
       />
+      {#if isFluid}
+        <hr className="bx--text-input__divider" />
+      {/if}
+      {#if isFluid && !inline && invalid}
+        <div class:bx--form-requirement="{true}" id="{errorId}">
+          {invalidText}
+        </div>
+      {/if}
+      {#if isFluid && !inline && warn}
+        <div class:bx--form-requirement="{true}" id="{warnId}">{warnText}</div>
+      {/if}
     </div>
-    {#if !invalid && !warn && !inline && helperText}
+    {#if !invalid && !warn && !isFluid && !inline && helperText}
       <div
         class:bx--form__helper-text="{true}"
         class:bx--form__helper-text--disabled="{disabled}"
@@ -216,12 +231,12 @@
         {helperText}
       </div>
     {/if}
-    {#if invalid}
+    {#if !isFluid && invalid}
       <div class:bx--form-requirement="{true}" id="{errorId}">
         {invalidText}
       </div>
     {/if}
-    {#if !invalid && warn}
+    {#if !isFluid && !invalid && warn}
       <div class:bx--form-requirement="{true}" id="{warnId}">{warnText}</div>
     {/if}
   </div>

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ export {
   Filename,
 } from "./FileUploader";
 export { Form } from "./Form";
+export { FluidForm } from "./FluidForm";
 export { FormGroup } from "./FormGroup";
 export { FormItem } from "./FormItem";
 export { FormLabel } from "./FormLabel";


### PR DESCRIPTION
fixes #285 

## Description

- adds `FluidForm`
- adds `FormContext.svelte`
  - access via `getContext("Form")`
- adds fluid variations to `TextInput` and a minor change to `PasswordInput`

## Notes

There has been an issue filed with the flagship Carbon repo in regards to an unintended misalignment with the "toggle visibility" button in `PasswordInput` in a `FluidForm` https://github.com/carbon-design-system/carbon/issues/6934