### PR TITLE
fix ComposedModal body classes, remove i10n locales from DatePicker

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -90,12 +90,12 @@
       if (!open) {
         opened = false;
         dispatch("close");
-        document.body.classList.add("bx--body--with-modal-open");
+        document.body.classList.remove("bx--body--with-modal-open");
       }
     } else if (open) {
       opened = true;
       dispatch("open");
-      document.body.classList.remove("bx--body--with-modal-open");
+      document.body.classList.add("bx--body--with-modal-open");
     }
   });
 </script>

--- a/src/DatePicker/createCalendar.js
+++ b/src/DatePicker/createCalendar.js
@@ -1,5 +1,4 @@
 import flatpickr from "flatpickr";
-import l10n from "flatpickr/dist/l10n/index.js";
 import rangePlugin from "flatpickr/dist/plugins/rangePlugin";
 
 function updateClasses(instance) {


### PR DESCRIPTION
ComposedModal body classes were reversed in the code logic.
Removing i10n locales from Datepicker saves 41972 bytes from the total build bundle size. Also, I think they shouldn't be preinstalled, developers can add them depending on their app requirements.