### PR TITLE
chore: remove prepack from pre-commit git hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "yarn prepack && lint-staged"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Per an offline discussion with @metonym `yarn prepack` should be removed from the pre-commit git hook in favor of running prepack in Travis and reducing the time for committing. 