### PR TITLE
Alignment

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -462,10 +462,11 @@ import { ButtonSkeleton } from "carbon-components-svelte";
 
 ### Props
 
-| Prop name | Type                 | Default value |
-| :-------- | :------------------- | :------------ |
-| href      | <code>string</code>  | --            |
-| small     | <code>boolean</code> | false         |
+| Prop name | Type                                                 | Default value |
+| :-------- | :--------------------------------------------------- | :------------ |
+| href      | <code>string</code>                                  | --            |
+| size      | <code>"default" &#124; "field" &#124; "small"</code> | "default"     |
+| small     | <code>boolean</code>                                 | false         |
 
 ### Slots
 
@@ -3219,6 +3220,7 @@ import { ProgressIndicatorSkeleton } from "carbon-components-svelte";
 | Prop name | Type                 | Default value |
 | :-------- | :------------------- | :------------ |
 | vertical  | <code>boolean</code> | false         |
+| count     | <code>number</code>  | 4             |
 
 ### Slots
 

--- a/docs/src/pages/components/Breadcrumb.svx
+++ b/docs/src/pages/components/Breadcrumb.svx
@@ -23,4 +23,4 @@
 
 ### Skeleton
 
-<Breadcrumb skeleton count={3} />
+<Breadcrumb noTrailingSlash skeleton count={3} />

--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -69,3 +69,5 @@ description: High-level description
 ### Skeleton
 
 <Button skeleton />
+<Button skeleton size="field" />
+<Button skeleton size="small" />

--- a/docs/src/pages/components/ProgressIndicator.svx
+++ b/docs/src/pages/components/ProgressIndicator.svx
@@ -56,4 +56,4 @@
 
 ### Skeleton
 
-<ProgressIndicatorSkeleton />
+<ProgressIndicatorSkeleton count={3} />

--- a/docs/src/pages/components/SkeletonText.svx
+++ b/docs/src/pages/components/SkeletonText.svx
@@ -19,6 +19,10 @@
 
 <SkeletonText paragraph />
 
+### Paragraph with custom line count
+
+<SkeletonText paragraph lines={8} />
+
 ### Paragraph with max width
 
 <SkeletonText paragraph width="50%" />

--- a/src/Breadcrumb/Breadcrumb.svelte
+++ b/src/Breadcrumb/Breadcrumb.svelte
@@ -16,6 +16,7 @@
 
 {#if skeleton}
   <BreadcrumbSkeleton
+    noTrailingSlash="{noTrailingSlash}"
     {...$$restProps}
     on:click
     on:mouseover

--- a/src/Button/Button.Skeleton.svelte
+++ b/src/Button/Button.Skeleton.svelte
@@ -6,6 +6,12 @@
   export let href = undefined;
 
   /**
+   * Specify the size of button skeleton
+   * @type {"default" | "field" | "small"} [size="default"]
+   */
+  export let size = "default";
+
+  /**
    * Set to `true` to use the small variant
    * @type {boolean} [small=false]
    */
@@ -19,7 +25,8 @@
     role="button"
     class:bx--skeleton="{true}"
     class:bx--btn="{true}"
-    class:bx--btn--sm="{small}"
+    class:bx--btn--field="{size === 'field'}"
+    class:bx--btn--sm="{size === 'small' || small}"
     {...$$restProps}
     on:click
     on:mouseover
@@ -32,7 +39,8 @@
   <div
     class:bx--skeleton="{true}"
     class:bx--btn="{true}"
-    class:bx--btn--sm="{small}"
+    class:bx--btn--field="{size === 'field'}"
+    class:bx--btn--sm="{size === 'small' || small}"
     {...$$restProps}
     on:click
     on:mouseover

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -123,7 +123,7 @@
 {#if skeleton}
   <ButtonSkeleton
     href="{href}"
-    small="{size === 'small'}"
+    size="{size}"
     {...$$restProps}
     style="{hasIconOnly && 'width: 3rem;'}"
     on:click

--- a/src/Icon/Icon.svelte
+++ b/src/Icon/Icon.svelte
@@ -13,14 +13,10 @@
   export let skeleton = false;
 
   import IconSkeleton from "./Icon.Skeleton.svelte";
-
-  $: iconName = render.toString().split(" ")[1];
-  $: size = parseInt(iconName.slice(-2), 10);
 </script>
 
 {#if skeleton}
   <IconSkeleton
-    size="{size}"
     {...$$restProps}
     on:click
     on:mouseover

--- a/src/InlineLoading/InlineLoading.svelte
+++ b/src/InlineLoading/InlineLoading.svelte
@@ -48,6 +48,7 @@
 </script>
 
 <div
+  class:bx--inline-loading="{true}"
   aria-live="assertive"
   {...$$restProps}
   on:click

--- a/src/ProgressIndicator/ProgressIndicator.Skeleton.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.Skeleton.svelte
@@ -4,6 +4,12 @@
    * @type {boolean} [vertical=false]
    */
   export let vertical = false;
+
+  /**
+   * Specify the number of steps to render
+   * @type {number} [count=4]
+   */
+  export let count = 4;
 </script>
 
 <ul
@@ -16,7 +22,7 @@
   on:mouseenter
   on:mouseleave
 >
-  {#each [0, 1, 2, 3] as item, i (item)}
+  {#each Array.from({ length: count }, (_, i) => i) as item, i (item)}
     <li
       class:bx--progress-step="{true}"
       class:bx--progress-step--incomplete="{true}"

--- a/src/SkeletonText/SkeletonText.svelte
+++ b/src/SkeletonText/SkeletonText.svelte
@@ -45,7 +45,7 @@
 
 {#if paragraph}
   <div {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
-    {#each rows as { width }, i (width)}
+    {#each rows as { width }}
       <p
         class:bx--skeleton__text="{true}"
         class:bx--skeleton__heading="{heading}"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -227,7 +227,13 @@ export class ButtonSkeleton extends CarbonSvelteComponent {
     href?: string;
 
     /**
-     * Set to `true` to use the small variant
+     * Specify the size of button skeleton
+     * @default "default"
+     */
+    size?: "default" | "field" | "small";
+
+    /**
+     *
      * @default false
      */
     small?: boolean;
@@ -3144,6 +3150,12 @@ export class ProgressIndicatorSkeleton extends CarbonSvelteComponent {
      * @default false
      */
     vertical?: boolean;
+
+    /**
+     * Specify the number of steps to render
+     * @default 4
+     */
+    count?: number;
   };
 }
 


### PR DESCRIPTION
Hodgepodge of fixes from the backlog.

**Features**

- feat(button-skeleton): add size prop consistent with Button
- feat(progress-indicator-skeleton): add count prop

**Fixes**

- fix(inline-loading): add wrapper class "bx--inline-loading"
- fix(breadcrumb): forward noTrailingSlash to skeleton
- fix(skeleton-text): unkey paragraph rows due to high collision rate

**Refactor**

- refactor(icon): remove old logic that inferred icon size from function name

**Documentation**

- Breadcrumb: use `noTrailingSlash` in skeleton example
- Button: demo skeleton size variants
- SkeletonText: added example "Paragraph with custom line count"
- ProgressIndicator: demo custom step count for skeleton
