### PR TITLE
fix(ComposedModal): remove bx--body--with-modal-open from body classes after destroy

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -47,6 +47,7 @@
     setContext,
     onMount,
     afterUpdate,
+    onDestroy,
   } from "svelte";
 
   const dispatch = createEventDispatcher();
@@ -79,11 +80,11 @@
   onMount(async () => {
     await tick();
     focus();
-
-    return () => {
-      document.body.classList.remove("bx--body--with-modal-open");
-    };
   });
+
+  onDestroy(() => {
+    document.body.classList.remove("bx--body--with-modal-open");
+  })
 
   afterUpdate(() => {
     if (opened) {


### PR DESCRIPTION
When onMount is async, the returned function is not executed: https://github.com/sveltejs/svelte/issues/4927
Because the class is not remove from the body, the code should be moved to a onDestroy function.