### PR TITLE
Forward scroll event for ComboBox and add a reference to the list HTML element

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -106,6 +106,12 @@
    * @type {null | HTMLInputElement} [ref=null]
    */
   export let ref = null;
+  
+	/**
+	 * Obtain a reference to the list HTML element
+	 * @type {null | HTMLElement} [ref=null]
+	 */
+	export let listRef = null  
 
   /**
    * @typedef {{ id: string; text: string; }} ComboBoxItem
@@ -284,7 +290,7 @@
       />
     </ListBoxField>
     {#if open}
-      <ListBoxMenu aria-label="{ariaLabel}" id="{id}">
+      <ListBoxMenu aria-label="{ariaLabel}" id="{id}" on:scroll bind:ref={listRef}>
         {#each filteredItems as item, i (item.id)}
           <ListBoxMenuItem
             id="{item.id}"

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -109,7 +109,7 @@
   
 	/**
 	 * Obtain a reference to the list HTML element
-	 * @type {null | HTMLElement} [ref=null]
+	 * @type {null | HTMLDivElement} [ref=null]
 	 */
 	export let listRef = null  
 

--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -18,6 +18,7 @@
   id="menu-{id}"
   class:bx--list-box__menu="{true}"
   {...$$restProps}
+  on:scroll
 >
   <slot />
 </div>


### PR DESCRIPTION
This prepares the ComboBox for a "infinite" loading scenario: we watch the scroll position of the list, so when the user scrolls and reaches the end of the list then we can append some new items to the list.