### PR TITLE
DataTable: add ToolbarMenu, ToolbarMenuItem, fix batch actions selection cancellation

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -5372,7 +5372,8 @@ No exported props.
 
 ### Forwarded events
 
-No forwarded events.
+- `on:click`
+- `on:keydown`
 
 ### Dispatched events
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1,6 +1,6 @@
 # Component Index
 
-> 152 components exported from carbon-components-svelte 0.20.0
+> 154 components exported from carbon-components-svelte 0.20.0
 
 - Accordion
   - [Accordion](#accordion)
@@ -44,6 +44,8 @@
   - [Toolbar](#toolbar)
   - [ToolbarBatchActions](#toolbarbatchactions)
   - [ToolbarContent](#toolbarcontent)
+  - [ToolbarMenu](#toolbarmenu)
+  - [ToolbarMenuItem](#toolbarmenuitem)
   - [ToolbarSearch](#toolbarsearch)
 - [DataTableSkeleton](#datatableskeleton)
 - DatePicker
@@ -796,6 +798,7 @@ interface ComboBoxItem {
 | id               | <code>string</code>                                         | --            | Set an id for the list box component.                                     |
 | name             | <code>string</code>                                         | --            | Specify a name attribute for the input.                                   |
 | ref              | <code>null &#124; HTMLInputElement</code>                   | `null`        | Obtain a reference to the input HTML element.                             |
+| listRef          | <code>null &#124; HTMLDivElement</code>                     | `null`        | Obtain a reference to the list HTML element.                              |
 
 ### Slots
 
@@ -807,6 +810,7 @@ No slots.
 - `on:focus`
 - `on:blur`
 - `on:clear`
+- `on:scroll`
 
 ### Dispatched events
 
@@ -2363,7 +2367,7 @@ import { ListBoxMenu } from "carbon-components-svelte";
 
 ### Forwarded events
 
-No forwarded events.
+- `on:scroll`
 
 ### Dispatched events
 
@@ -3019,6 +3023,8 @@ import { OverflowMenu } from "carbon-components-svelte";
 | iconClass        | <code>string</code>                                                 | --                                 | Specify the icon class.                                            |
 | iconDescription  | <code>string</code>                                                 | `"Open and close list of options"` | Specify the ARIA label for the icon.                               |
 | id               | <code>string</code>                                                 | --                                 | Set an id for the button element.                                  |
+| buttonRef        | <code>null &#124; HTMLButtonElement</code>                          | `null`                             | Obtain a reference to the trigger button element.                  |
+| menuRef          | <code>null &#124; HTMLUListElement</code>                           | `null`                             | Obtain a reference to the overflow menu element.                   |
 
 ### Slots
 
@@ -5302,6 +5308,58 @@ No dispatched events.
 
 ```js
 import { ToolbarContent } from "carbon-components-svelte";
+```
+
+### Props
+
+No exported props.
+
+### Slots
+
+- **default**: `<div>...</div>`
+
+### Forwarded events
+
+No forwarded events.
+
+### Dispatched events
+
+No dispatched events.
+
+---
+
+## ToolbarMenu
+
+### Import path
+
+```js
+import { ToolbarMenu } from "carbon-components-svelte";
+```
+
+### Props
+
+No exported props.
+
+### Slots
+
+- **default**: `<div>...</div>`
+
+### Forwarded events
+
+No forwarded events.
+
+### Dispatched events
+
+No dispatched events.
+
+---
+
+## ToolbarMenuItem
+
+### Import path
+
+```js
+import { ToolbarMenuItem } from "carbon-components-svelte";
 ```
 
 ### Props

--- a/docs/src/PUBLIC_API.json
+++ b/docs/src/PUBLIC_API.json
@@ -1950,6 +1950,15 @@
             "type": "null | HTMLInputElement",
             "description": "Obtain a reference to the input HTML element"
           }
+        ],
+        [
+          "listRef",
+          {
+            "kind": "let",
+            "value": "null",
+            "type": "null | HTMLDivElement",
+            "description": "Obtain a reference to the list HTML element"
+          }
         ]
       ],
       "slots": [],
@@ -1957,8 +1966,8 @@
         [
           "keydown",
           {
-            "start": 5481,
-            "end": 5491,
+            "start": 5616,
+            "end": 5626,
             "type": "EventHandler",
             "name": "keydown",
             "modifiers": [],
@@ -1968,8 +1977,8 @@
         [
           "focus",
           {
-            "start": 6068,
-            "end": 6076,
+            "start": 6203,
+            "end": 6211,
             "type": "EventHandler",
             "name": "focus",
             "modifiers": [],
@@ -1979,8 +1988,8 @@
         [
           "blur",
           {
-            "start": 6085,
-            "end": 6092,
+            "start": 6220,
+            "end": 6227,
             "type": "EventHandler",
             "name": "blur",
             "modifiers": [],
@@ -1990,10 +1999,21 @@
         [
           "clear",
           {
-            "start": 6543,
-            "end": 6551,
+            "start": 6678,
+            "end": 6686,
             "type": "EventHandler",
             "name": "clear",
+            "modifiers": [],
+            "expression": null
+          }
+        ],
+        [
+          "scroll",
+          {
+            "start": 7220,
+            "end": 7229,
+            "type": "EventHandler",
+            "name": "scroll",
             "modifiers": [],
             "expression": null
           }
@@ -6967,7 +6987,19 @@
           }
         ]
       ],
-      "forwarded_events": [],
+      "forwarded_events": [
+        [
+          "scroll",
+          {
+            "start": 403,
+            "end": 412,
+            "type": "EventHandler",
+            "name": "scroll",
+            "modifiers": [],
+            "expression": null
+          }
+        ]
+      ],
       "dispatched_events": []
     },
     "ListBoxMenuIcon": {
@@ -8800,6 +8832,24 @@
             "type": "string",
             "description": "Set an id for the button element"
           }
+        ],
+        [
+          "buttonRef",
+          {
+            "kind": "let",
+            "value": "null",
+            "type": "null | HTMLButtonElement",
+            "description": "Obtain a reference to the trigger button element"
+          }
+        ],
+        [
+          "menuRef",
+          {
+            "kind": "let",
+            "value": "null",
+            "type": "null | HTMLUListElement",
+            "description": "Obtain a reference to the overflow menu element"
+          }
         ]
       ],
       "slots": [
@@ -8808,14 +8858,14 @@
           {
             "attributes": [
               {
-                "start": 4567,
-                "end": 4578,
+                "start": 4805,
+                "end": 4816,
                 "type": "Attribute",
                 "name": "name",
                 "value": [
                   {
-                    "start": 4573,
-                    "end": 4577,
+                    "start": 4811,
+                    "end": 4815,
                     "type": "Text",
                     "raw": "menu",
                     "data": "menu"
@@ -8825,39 +8875,39 @@
             ],
             "children": [
               {
-                "start": 4579,
-                "end": 4584,
+                "start": 4817,
+                "end": 4822,
                 "type": "Text",
                 "raw": "\n    ",
                 "data": "\n    "
               },
               {
-                "start": 4584,
-                "end": 4747,
+                "start": 4822,
+                "end": 4985,
                 "type": "InlineComponent",
                 "name": "svelte:component",
                 "attributes": [
                   {
-                    "start": 4628,
-                    "end": 4658,
+                    "start": 4866,
+                    "end": 4896,
                     "type": "Attribute",
                     "name": "aria-label",
                     "value": [
                       {
-                        "start": 4640,
-                        "end": 4657,
+                        "start": 4878,
+                        "end": 4895,
                         "type": "MustacheTag",
                         "expression": {
                           "type": "Identifier",
-                          "start": 4641,
-                          "end": 4656,
+                          "start": 4879,
+                          "end": 4894,
                           "loc": {
                             "start": {
-                              "line": 196,
+                              "line": 206,
                               "column": 19
                             },
                             "end": {
-                              "line": 196,
+                              "line": 206,
                               "column": 34
                             }
                           },
@@ -8867,26 +8917,26 @@
                     ]
                   },
                   {
-                    "start": 4665,
-                    "end": 4690,
+                    "start": 4903,
+                    "end": 4928,
                     "type": "Attribute",
                     "name": "title",
                     "value": [
                       {
-                        "start": 4672,
-                        "end": 4689,
+                        "start": 4910,
+                        "end": 4927,
                         "type": "MustacheTag",
                         "expression": {
                           "type": "Identifier",
-                          "start": 4673,
-                          "end": 4688,
+                          "start": 4911,
+                          "end": 4926,
                           "loc": {
                             "start": {
-                              "line": 197,
+                              "line": 207,
                               "column": 14
                             },
                             "end": {
-                              "line": 197,
+                              "line": 207,
                               "column": 29
                             }
                           },
@@ -8896,33 +8946,33 @@
                     ]
                   },
                   {
-                    "start": 4697,
-                    "end": 4740,
+                    "start": 4935,
+                    "end": 4978,
                     "type": "Attribute",
                     "name": "class",
                     "value": [
                       {
-                        "start": 4704,
-                        "end": 4729,
+                        "start": 4942,
+                        "end": 4967,
                         "type": "Text",
                         "raw": "bx--overflow-menu__icon ",
                         "data": "bx--overflow-menu__icon "
                       },
                       {
-                        "start": 4728,
-                        "end": 4739,
+                        "start": 4966,
+                        "end": 4977,
                         "type": "MustacheTag",
                         "expression": {
                           "type": "Identifier",
-                          "start": 4729,
-                          "end": 4738,
+                          "start": 4967,
+                          "end": 4976,
                           "loc": {
                             "start": {
-                              "line": 198,
+                              "line": 208,
                               "column": 38
                             },
                             "end": {
-                              "line": 198,
+                              "line": 208,
                               "column": 47
                             }
                           },
@@ -8935,15 +8985,15 @@
                 "children": [],
                 "expression": {
                   "type": "Identifier",
-                  "start": 4615,
-                  "end": 4619,
+                  "start": 4853,
+                  "end": 4857,
                   "loc": {
                     "start": {
-                      "line": 195,
+                      "line": 205,
                       "column": 13
                     },
                     "end": {
-                      "line": 195,
+                      "line": 205,
                       "column": 17
                     }
                   },
@@ -8951,8 +9001,8 @@
                 }
               },
               {
-                "start": 4747,
-                "end": 4750,
+                "start": 4985,
+                "end": 4988,
                 "type": "Text",
                 "raw": "\n  ",
                 "data": "\n  "
@@ -8976,8 +9026,8 @@
         [
           "click",
           {
-            "start": 4089,
-            "end": 4097,
+            "start": 4327,
+            "end": 4335,
             "type": "EventHandler",
             "name": "click",
             "modifiers": [],
@@ -8987,8 +9037,8 @@
         [
           "mouseover",
           {
-            "start": 4213,
-            "end": 4225,
+            "start": 4451,
+            "end": 4463,
             "type": "EventHandler",
             "name": "mouseover",
             "modifiers": [],
@@ -8998,8 +9048,8 @@
         [
           "mouseenter",
           {
-            "start": 4228,
-            "end": 4241,
+            "start": 4466,
+            "end": 4479,
             "type": "EventHandler",
             "name": "mouseenter",
             "modifiers": [],
@@ -9009,8 +9059,8 @@
         [
           "mouseleave",
           {
-            "start": 4244,
-            "end": 4257,
+            "start": 4482,
+            "end": 4495,
             "type": "EventHandler",
             "name": "mouseleave",
             "modifiers": [],
@@ -9020,8 +9070,8 @@
         [
           "keydown",
           {
-            "start": 4260,
-            "end": 4270,
+            "start": 4498,
+            "end": 4508,
             "type": "EventHandler",
             "name": "keydown",
             "modifiers": [],
@@ -15548,6 +15598,40 @@
     },
     "ToolbarContent": {
       "moduleName": "ToolbarContent",
+      "props": [],
+      "slots": [
+        [
+          "default",
+          {
+            "attributes": [],
+            "children": [],
+            "default": true,
+            "default_value": ""
+          }
+        ]
+      ],
+      "forwarded_events": [],
+      "dispatched_events": []
+    },
+    "ToolbarMenu": {
+      "moduleName": "ToolbarMenu",
+      "props": [],
+      "slots": [
+        [
+          "default",
+          {
+            "attributes": [],
+            "children": [],
+            "default": true,
+            "default_value": ""
+          }
+        ]
+      ],
+      "forwarded_events": [],
+      "dispatched_events": []
+    },
+    "ToolbarMenuItem": {
+      "moduleName": "ToolbarMenuItem",
       "props": [],
       "slots": [
         [

--- a/docs/src/PUBLIC_API.json
+++ b/docs/src/PUBLIC_API.json
@@ -1966,8 +1966,8 @@
         [
           "keydown",
           {
-            "start": 5616,
-            "end": 5626,
+            "start": 5618,
+            "end": 5628,
             "type": "EventHandler",
             "name": "keydown",
             "modifiers": [],
@@ -1977,8 +1977,8 @@
         [
           "focus",
           {
-            "start": 6203,
-            "end": 6211,
+            "start": 6205,
+            "end": 6213,
             "type": "EventHandler",
             "name": "focus",
             "modifiers": [],
@@ -1988,8 +1988,8 @@
         [
           "blur",
           {
-            "start": 6220,
-            "end": 6227,
+            "start": 6222,
+            "end": 6229,
             "type": "EventHandler",
             "name": "blur",
             "modifiers": [],
@@ -1999,8 +1999,8 @@
         [
           "clear",
           {
-            "start": 6678,
-            "end": 6686,
+            "start": 6680,
+            "end": 6688,
             "type": "EventHandler",
             "name": "clear",
             "modifiers": [],
@@ -2010,8 +2010,8 @@
         [
           "scroll",
           {
-            "start": 7220,
-            "end": 7229,
+            "start": 7246,
+            "end": 7255,
             "type": "EventHandler",
             "name": "scroll",
             "modifiers": [],
@@ -15644,7 +15644,30 @@
           }
         ]
       ],
-      "forwarded_events": [],
+      "forwarded_events": [
+        [
+          "click",
+          {
+            "start": 109,
+            "end": 117,
+            "type": "EventHandler",
+            "name": "click",
+            "modifiers": [],
+            "expression": null
+          }
+        ],
+        [
+          "keydown",
+          {
+            "start": 118,
+            "end": 128,
+            "type": "EventHandler",
+            "name": "keydown",
+            "modifiers": [],
+            "expression": null
+          }
+        ]
+      ],
       "dispatched_events": []
     },
     "ToolbarSearch": {

--- a/docs/src/PUBLIC_API.json
+++ b/docs/src/PUBLIC_API.json
@@ -2677,14 +2677,14 @@
           {
             "attributes": [
               {
-                "start": 7427,
-                "end": 7445,
+                "start": 7574,
+                "end": 7592,
                 "type": "Attribute",
                 "name": "name",
                 "value": [
                   {
-                    "start": 7433,
-                    "end": 7444,
+                    "start": 7580,
+                    "end": 7591,
                     "type": "Text",
                     "raw": "cell-header",
                     "data": "cell-header"
@@ -2692,26 +2692,26 @@
                 ]
               },
               {
-                "start": 7446,
-                "end": 7463,
+                "start": 7593,
+                "end": 7610,
                 "type": "Attribute",
                 "name": "header",
                 "value": [
                   {
-                    "start": 7454,
-                    "end": 7462,
+                    "start": 7601,
+                    "end": 7609,
                     "type": "MustacheTag",
                     "expression": {
                       "type": "Identifier",
-                      "start": 7455,
-                      "end": 7461,
+                      "start": 7602,
+                      "end": 7608,
                       "loc": {
                         "start": {
-                          "line": 260,
+                          "line": 265,
                           "column": 46
                         },
                         "end": {
-                          "line": 260,
+                          "line": 265,
                           "column": 52
                         }
                       },
@@ -2723,34 +2723,34 @@
             ],
             "children": [
               {
-                "start": 7464,
-                "end": 7478,
+                "start": 7611,
+                "end": 7625,
                 "type": "MustacheTag",
                 "expression": {
                   "type": "MemberExpression",
-                  "start": 7465,
-                  "end": 7477,
+                  "start": 7612,
+                  "end": 7624,
                   "loc": {
                     "start": {
-                      "line": 260,
+                      "line": 265,
                       "column": 56
                     },
                     "end": {
-                      "line": 260,
+                      "line": 265,
                       "column": 68
                     }
                   },
                   "object": {
                     "type": "Identifier",
-                    "start": 7465,
-                    "end": 7471,
+                    "start": 7612,
+                    "end": 7618,
                     "loc": {
                       "start": {
-                        "line": 260,
+                        "line": 265,
                         "column": 56
                       },
                       "end": {
-                        "line": 260,
+                        "line": 265,
                         "column": 62
                       }
                     },
@@ -2758,15 +2758,15 @@
                   },
                   "property": {
                     "type": "Identifier",
-                    "start": 7472,
-                    "end": 7477,
+                    "start": 7619,
+                    "end": 7624,
                     "loc": {
                       "start": {
-                        "line": 260,
+                        "line": 265,
                         "column": 63
                       },
                       "end": {
-                        "line": 260,
+                        "line": 265,
                         "column": 68
                       }
                     },
@@ -2786,14 +2786,14 @@
           {
             "attributes": [
               {
-                "start": 10474,
-                "end": 10485,
+                "start": 10621,
+                "end": 10632,
                 "type": "Attribute",
                 "name": "name",
                 "value": [
                   {
-                    "start": 10480,
-                    "end": 10484,
+                    "start": 10627,
+                    "end": 10631,
                     "type": "Text",
                     "raw": "cell",
                     "data": "cell"
@@ -2801,26 +2801,26 @@
                 ]
               },
               {
-                "start": 10486,
-                "end": 10497,
+                "start": 10633,
+                "end": 10644,
                 "type": "Attribute",
                 "name": "row",
                 "value": [
                   {
-                    "start": 10491,
-                    "end": 10496,
+                    "start": 10638,
+                    "end": 10643,
                     "type": "MustacheTag",
                     "expression": {
                       "type": "Identifier",
-                      "start": 10492,
-                      "end": 10495,
+                      "start": 10639,
+                      "end": 10642,
                       "loc": {
                         "start": {
-                          "line": 341,
+                          "line": 346,
                           "column": 38
                         },
                         "end": {
-                          "line": 341,
+                          "line": 346,
                           "column": 41
                         }
                       },
@@ -2830,26 +2830,26 @@
                 ]
               },
               {
-                "start": 10498,
-                "end": 10511,
+                "start": 10645,
+                "end": 10658,
                 "type": "Attribute",
                 "name": "cell",
                 "value": [
                   {
-                    "start": 10504,
-                    "end": 10510,
+                    "start": 10651,
+                    "end": 10657,
                     "type": "MustacheTag",
                     "expression": {
                       "type": "Identifier",
-                      "start": 10505,
-                      "end": 10509,
+                      "start": 10652,
+                      "end": 10656,
                       "loc": {
                         "start": {
-                          "line": 341,
+                          "line": 346,
                           "column": 51
                         },
                         "end": {
-                          "line": 341,
+                          "line": 346,
                           "column": 55
                         }
                       },
@@ -2861,69 +2861,69 @@
             ],
             "children": [
               {
-                "start": 10512,
-                "end": 10529,
+                "start": 10659,
+                "end": 10676,
                 "type": "Text",
                 "raw": "\n                ",
                 "data": "\n                "
               },
               {
-                "start": 10529,
-                "end": 10595,
+                "start": 10676,
+                "end": 10742,
                 "type": "MustacheTag",
                 "expression": {
                   "type": "ConditionalExpression",
-                  "start": 10530,
-                  "end": 10594,
+                  "start": 10677,
+                  "end": 10741,
                   "loc": {
                     "start": {
-                      "line": 342,
+                      "line": 347,
                       "column": 17
                     },
                     "end": {
-                      "line": 342,
+                      "line": 347,
                       "column": 81
                     }
                   },
                   "test": {
                     "type": "MemberExpression",
-                    "start": 10530,
-                    "end": 10548,
+                    "start": 10677,
+                    "end": 10695,
                     "loc": {
                       "start": {
-                        "line": 342,
+                        "line": 347,
                         "column": 17
                       },
                       "end": {
-                        "line": 342,
+                        "line": 347,
                         "column": 35
                       }
                     },
                     "object": {
                       "type": "MemberExpression",
-                      "start": 10530,
-                      "end": 10540,
+                      "start": 10677,
+                      "end": 10687,
                       "loc": {
                         "start": {
-                          "line": 342,
+                          "line": 347,
                           "column": 17
                         },
                         "end": {
-                          "line": 342,
+                          "line": 347,
                           "column": 27
                         }
                       },
                       "object": {
                         "type": "Identifier",
-                        "start": 10530,
-                        "end": 10537,
+                        "start": 10677,
+                        "end": 10684,
                         "loc": {
                           "start": {
-                            "line": 342,
+                            "line": 347,
                             "column": 17
                           },
                           "end": {
-                            "line": 342,
+                            "line": 347,
                             "column": 24
                           }
                         },
@@ -2931,15 +2931,15 @@
                       },
                       "property": {
                         "type": "Identifier",
-                        "start": 10538,
-                        "end": 10539,
+                        "start": 10685,
+                        "end": 10686,
                         "loc": {
                           "start": {
-                            "line": 342,
+                            "line": 347,
                             "column": 25
                           },
                           "end": {
-                            "line": 342,
+                            "line": 347,
                             "column": 26
                           }
                         },
@@ -2950,15 +2950,15 @@
                     },
                     "property": {
                       "type": "Identifier",
-                      "start": 10541,
-                      "end": 10548,
+                      "start": 10688,
+                      "end": 10695,
                       "loc": {
                         "start": {
-                          "line": 342,
+                          "line": 347,
                           "column": 28
                         },
                         "end": {
-                          "line": 342,
+                          "line": 347,
                           "column": 35
                         }
                       },
@@ -2969,57 +2969,57 @@
                   },
                   "consequent": {
                     "type": "CallExpression",
-                    "start": 10551,
-                    "end": 10581,
+                    "start": 10698,
+                    "end": 10728,
                     "loc": {
                       "start": {
-                        "line": 342,
+                        "line": 347,
                         "column": 38
                       },
                       "end": {
-                        "line": 342,
+                        "line": 347,
                         "column": 68
                       }
                     },
                     "callee": {
                       "type": "MemberExpression",
-                      "start": 10551,
-                      "end": 10569,
+                      "start": 10698,
+                      "end": 10716,
                       "loc": {
                         "start": {
-                          "line": 342,
+                          "line": 347,
                           "column": 38
                         },
                         "end": {
-                          "line": 342,
+                          "line": 347,
                           "column": 56
                         }
                       },
                       "object": {
                         "type": "MemberExpression",
-                        "start": 10551,
-                        "end": 10561,
+                        "start": 10698,
+                        "end": 10708,
                         "loc": {
                           "start": {
-                            "line": 342,
+                            "line": 347,
                             "column": 38
                           },
                           "end": {
-                            "line": 342,
+                            "line": 347,
                             "column": 48
                           }
                         },
                         "object": {
                           "type": "Identifier",
-                          "start": 10551,
-                          "end": 10558,
+                          "start": 10698,
+                          "end": 10705,
                           "loc": {
                             "start": {
-                              "line": 342,
+                              "line": 347,
                               "column": 38
                             },
                             "end": {
-                              "line": 342,
+                              "line": 347,
                               "column": 45
                             }
                           },
@@ -3027,15 +3027,15 @@
                         },
                         "property": {
                           "type": "Identifier",
-                          "start": 10559,
-                          "end": 10560,
+                          "start": 10706,
+                          "end": 10707,
                           "loc": {
                             "start": {
-                              "line": 342,
+                              "line": 347,
                               "column": 46
                             },
                             "end": {
-                              "line": 342,
+                              "line": 347,
                               "column": 47
                             }
                           },
@@ -3046,15 +3046,15 @@
                       },
                       "property": {
                         "type": "Identifier",
-                        "start": 10562,
-                        "end": 10569,
+                        "start": 10709,
+                        "end": 10716,
                         "loc": {
                           "start": {
-                            "line": 342,
+                            "line": 347,
                             "column": 49
                           },
                           "end": {
-                            "line": 342,
+                            "line": 347,
                             "column": 56
                           }
                         },
@@ -3066,29 +3066,29 @@
                     "arguments": [
                       {
                         "type": "MemberExpression",
-                        "start": 10570,
-                        "end": 10580,
+                        "start": 10717,
+                        "end": 10727,
                         "loc": {
                           "start": {
-                            "line": 342,
+                            "line": 347,
                             "column": 57
                           },
                           "end": {
-                            "line": 342,
+                            "line": 347,
                             "column": 67
                           }
                         },
                         "object": {
                           "type": "Identifier",
-                          "start": 10570,
-                          "end": 10574,
+                          "start": 10717,
+                          "end": 10721,
                           "loc": {
                             "start": {
-                              "line": 342,
+                              "line": 347,
                               "column": 57
                             },
                             "end": {
-                              "line": 342,
+                              "line": 347,
                               "column": 61
                             }
                           },
@@ -3096,15 +3096,15 @@
                         },
                         "property": {
                           "type": "Identifier",
-                          "start": 10575,
-                          "end": 10580,
+                          "start": 10722,
+                          "end": 10727,
                           "loc": {
                             "start": {
-                              "line": 342,
+                              "line": 347,
                               "column": 62
                             },
                             "end": {
-                              "line": 342,
+                              "line": 347,
                               "column": 67
                             }
                           },
@@ -3118,29 +3118,29 @@
                   },
                   "alternate": {
                     "type": "MemberExpression",
-                    "start": 10584,
-                    "end": 10594,
+                    "start": 10731,
+                    "end": 10741,
                     "loc": {
                       "start": {
-                        "line": 342,
+                        "line": 347,
                         "column": 71
                       },
                       "end": {
-                        "line": 342,
+                        "line": 347,
                         "column": 81
                       }
                     },
                     "object": {
                       "type": "Identifier",
-                      "start": 10584,
-                      "end": 10588,
+                      "start": 10731,
+                      "end": 10735,
                       "loc": {
                         "start": {
-                          "line": 342,
+                          "line": 347,
                           "column": 71
                         },
                         "end": {
-                          "line": 342,
+                          "line": 347,
                           "column": 75
                         }
                       },
@@ -3148,15 +3148,15 @@
                     },
                     "property": {
                       "type": "Identifier",
-                      "start": 10589,
-                      "end": 10594,
+                      "start": 10736,
+                      "end": 10741,
                       "loc": {
                         "start": {
-                          "line": 342,
+                          "line": 347,
                           "column": 76
                         },
                         "end": {
-                          "line": 342,
+                          "line": 347,
                           "column": 81
                         }
                       },
@@ -3168,8 +3168,8 @@
                 }
               },
               {
-                "start": 10595,
-                "end": 10610,
+                "start": 10742,
+                "end": 10757,
                 "type": "Text",
                 "raw": "\n              ",
                 "data": "\n              "
@@ -3184,14 +3184,14 @@
           {
             "attributes": [
               {
-                "start": 11146,
-                "end": 11165,
+                "start": 11293,
+                "end": 11312,
                 "type": "Attribute",
                 "name": "name",
                 "value": [
                   {
-                    "start": 11152,
-                    "end": 11164,
+                    "start": 11299,
+                    "end": 11311,
                     "type": "Text",
                     "raw": "expanded-row",
                     "data": "expanded-row"
@@ -3199,26 +3199,26 @@
                 ]
               },
               {
-                "start": 11166,
-                "end": 11177,
+                "start": 11313,
+                "end": 11324,
                 "type": "Attribute",
                 "name": "row",
                 "value": [
                   {
-                    "start": 11171,
-                    "end": 11176,
+                    "start": 11318,
+                    "end": 11323,
                     "type": "MustacheTag",
                     "expression": {
                       "type": "Identifier",
-                      "start": 11172,
-                      "end": 11175,
+                      "start": 11319,
+                      "end": 11322,
                       "loc": {
                         "start": {
-                          "line": 361,
+                          "line": 366,
                           "column": 48
                         },
                         "end": {
-                          "line": 361,
+                          "line": 366,
                           "column": 51
                         }
                       },

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1,9 +1,9 @@
 ---
-components: ["DataTable", "Toolbar", "ToolbarContent", "ToolbarSearch", "ToolbarBatchActions"]
+components: ["DataTable", "Toolbar", "ToolbarContent", "ToolbarSearch", "ToolbarMenu", "ToolbarMenuItem", "ToolbarBatchActions"]
 ---
 
 <script>
-  import { DataTable, DataTableSkeleton, Toolbar, ToolbarContent, ToolbarSearch, Button, Link } from "carbon-components-svelte";
+  import { DataTable, DataTableSkeleton, Toolbar, ToolbarContent, ToolbarSearch, ToolbarMenu, ToolbarMenuItem, Button, Link } from "carbon-components-svelte";
   import Launch16 from "carbon-icons-svelte/lib/Launch16";
   import Preview from "../../components/Preview.svelte";
 </script>
@@ -316,7 +316,12 @@ The slot name for the table header cells is `"cell-header"`.
   <Toolbar>
     <ToolbarContent>
       <ToolbarSearch />
-      <Button>Create</Button>
+      <ToolbarMenu>
+        <ToolbarMenuItem primaryFocus>Restart all</ToolbarMenuItem>
+        <ToolbarMenuItem href="https://cloud.ibm.com/docs/loadbalancer-service">API Documentation</ToolbarMenuItem>
+        <ToolbarMenuItem danger>Stop all</ToolbarMenuItem>
+      </ToolbarMenu>
+      <Button>Create balancer</Button>
     </ToolbarContent>
   </Toolbar>
 </DataTable>
@@ -378,7 +383,12 @@ The slot name for the table header cells is `"cell-header"`.
   <Toolbar size="sm">
     <ToolbarContent>
       <ToolbarSearch />
-      <Button>Create</Button>
+      <ToolbarMenu>
+        <ToolbarMenuItem primaryFocus>Restart all</ToolbarMenuItem>
+        <ToolbarMenuItem href="https://cloud.ibm.com/docs/loadbalancer-service">API Documentation</ToolbarMenuItem>
+        <ToolbarMenuItem danger>Stop all</ToolbarMenuItem>
+      </ToolbarMenu>
+      <Button>Create balancer</Button>
     </ToolbarContent>
   </Toolbar>
 </DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableBatchSelectionToolbar.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableBatchSelectionToolbar.svelte
@@ -4,6 +4,8 @@
     Toolbar,
     ToolbarContent,
     ToolbarSearch,
+    ToolbarMenu,
+    ToolbarMenuItem,
     ToolbarBatchActions,
     Button,
   } from "carbon-components-svelte";
@@ -36,7 +38,14 @@
     </ToolbarBatchActions>
     <ToolbarContent>
       <ToolbarSearch />
-      <Button>Create</Button>
+      <ToolbarMenu>
+        <ToolbarMenuItem primaryFocus>Restart all</ToolbarMenuItem>
+        <ToolbarMenuItem href="https://cloud.ibm.com/docs/loadbalancer-service">
+          API Documentation
+        </ToolbarMenuItem>
+        <ToolbarMenuItem danger>Stop all</ToolbarMenuItem>
+      </ToolbarMenu>
+      <Button>Create balancer</Button>
     </ToolbarContent>
   </Toolbar>
 </DataTable>

--- a/src/Checkbox/InlineCheckbox.svelte
+++ b/src/Checkbox/InlineCheckbox.svelte
@@ -22,9 +22,16 @@
    * @type {string} [id]
    */
   export let id = "ccs-" + Math.random().toString(36);
+
+  /**
+   * Obtain a reference to the input HTML element
+   * @type {null | HTMLInputElement} [ref=null]
+   */
+  export let ref = null;
 </script>
 
 <input
+  bind:this="{ref}"
   type="checkbox"
   class:bx--checkbox="{true}"
   checked="{indeterminate ? false : checked}"

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -106,12 +106,12 @@
    * @type {null | HTMLInputElement} [ref=null]
    */
   export let ref = null;
-  
-	/**
-	 * Obtain a reference to the list HTML element
-	 * @type {null | HTMLDivElement} [ref=null]
-	 */
-	export let listRef = null  
+
+  /**
+   * Obtain a reference to the list HTML element
+   * @type {null | HTMLDivElement} [ref=null]
+   */
+  export let listRef = null;
 
   /**
    * @typedef {{ id: string; text: string; }} ComboBoxItem
@@ -290,7 +290,12 @@
       />
     </ListBoxField>
     {#if open}
-      <ListBoxMenu aria-label="{ariaLabel}" id="{id}" on:scroll bind:ref={listRef}>
+      <ListBoxMenu
+        aria-label="{ariaLabel}"
+        id="{id}"
+        on:scroll
+        bind:ref="{listRef}"
+      >
         {#each filteredItems as item, i (item.id)}
           <ListBoxMenuItem
             id="{item.id}"

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -131,7 +131,9 @@
     tableSortable,
     batchSelectedIds,
     resetSelectedRowIds: () => {
+      selectAll = false;
       selectedRowIds = [];
+      if (refSelectAll) refSelectAll.checked = false;
     },
     add: (id) => {
       headerItems.update((_) => [..._, id]);
@@ -147,6 +149,8 @@
   );
 
   let selectAll = false;
+  let refSelectAll = null;
+
   $: batchSelectedIds.set(selectedRowIds);
   $: indeterminate =
     selectedRowIds.length > 0 && selectedRowIds.length < rows.length;
@@ -221,6 +225,7 @@
         {#if batchSelection && !radio}
           <th scope="col" class:bx--table-column-checkbox="{true}">
             <InlineCheckbox
+              bind:ref="{refSelectAll}"
               aria-label="Select all rows"
               checked="{selectAll}"
               indeterminate="{indeterminate}"

--- a/src/DataTable/Toolbar.svelte
+++ b/src/DataTable/Toolbar.svelte
@@ -30,7 +30,5 @@
   class:bx--table-toolbar--normal="{size === 'default'}"
   {...$$restProps}
 >
-  <div class:bx--toolbar-content="{true}">
-    <slot />
-  </div>
+  <slot />
 </section>

--- a/src/DataTable/Toolbar.svelte
+++ b/src/DataTable/Toolbar.svelte
@@ -4,9 +4,26 @@
    * @type {"sm" | "default"} [size="default"]
    */
   export let size = "default";
+
+  import { setContext } from "svelte";
+
+  let ref = null;
+
+  setContext("Toolbar", {
+    setOverflow: (toggled) => {
+      if (ref) {
+        if (toggled) {
+          ref.style.overflow = "visible";
+        } else {
+          ref.removeAttribute("style");
+        }
+      }
+    },
+  });
 </script>
 
 <section
+  bind:this="{ref}"
   aria-label="data table toolbar"
   class:bx--table-toolbar="{true}"
   class:bx--table-toolbar--small="{size === 'sm'}"

--- a/src/DataTable/Toolbar.svelte
+++ b/src/DataTable/Toolbar.svelte
@@ -6,18 +6,17 @@
   export let size = "default";
 
   import { setContext } from "svelte";
+  import { writable } from "svelte/store";
 
   let ref = null;
 
+  const overflowVisible = writable(false);
+
   setContext("Toolbar", {
-    setOverflow: (toggled) => {
-      if (ref) {
-        if (toggled) {
-          ref.style.overflow = "visible";
-        } else {
-          ref.removeAttribute("style");
-        }
-      }
+    overflowVisible,
+    setOverflowVisible: (visible) => {
+      overflowVisible.set(visible);
+      if (ref) ref.style.overflow = visible ? "visible" : "inherit";
     },
   });
 </script>

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -18,27 +18,41 @@
     batchSelectedIds = value;
   });
 
-  onMount(() => unsubscribe);
+  let overflowVisible = false;
+
+  const ctxToolbar = getContext("Toolbar");
+  const unsubscribeOverflow = ctxToolbar.overflowVisible.subscribe((value) => {
+    overflowVisible = value;
+  });
+
+  onMount(() => {
+    return () => {
+      unsubscribe();
+      unsubscribeOverflow();
+    };
+  });
 </script>
 
-<div
-  class:bx--batch-actions="{true}"
-  class:bx--batch-actions--active="{showActions}"
-  {...$$restProps}
->
-  <div class:bx--batch-summary="{true}">
-    <p class:bx--batch-summary__para="{true}">
-      <span> {formatTotalSelected(batchSelectedIds.length)} </span>
-    </p>
+{#if !overflowVisible}
+  <div
+    class:bx--batch-actions="{true}"
+    class:bx--batch-actions--active="{showActions}"
+    {...$$restProps}
+  >
+    <div class:bx--batch-summary="{true}">
+      <p class:bx--batch-summary__para="{true}">
+        <span> {formatTotalSelected(batchSelectedIds.length)} </span>
+      </p>
+    </div>
+    <div class:bx--action-list="{true}">
+      <slot />
+      <Button
+        class="bx--batch-summary__cancel"
+        tabindex="{showActions ? '0' : '-1'}"
+        on:click="{ctx.resetSelectedRowIds}"
+      >
+        Cancel
+      </Button>
+    </div>
   </div>
-  <div class:bx--action-list="{true}">
-    <slot />
-    <Button
-      class="bx--batch-summary__cancel"
-      tabindex="{showActions ? '0' : '-1'}"
-      on:click="{ctx.resetSelectedRowIds}"
-    >
-      Cancel
-    </Button>
-  </div>
-</div>
+{/if}

--- a/src/DataTable/ToolbarMenu.svelte
+++ b/src/DataTable/ToolbarMenu.svelte
@@ -7,7 +7,7 @@
 
   let menuRef = null;
 
-  $: ctx.setOverflow(menuRef != null);
+  $: ctx.setOverflowVisible(menuRef != null);
   $: if (menuRef) menuRef.style.top = "100%";
 </script>
 

--- a/src/DataTable/ToolbarMenu.svelte
+++ b/src/DataTable/ToolbarMenu.svelte
@@ -1,0 +1,22 @@
+<script>
+  import { getContext } from "svelte";
+  import Settings16 from "carbon-icons-svelte/lib/Settings16";
+  import { OverflowMenu } from "../OverflowMenu";
+
+  const ctx = getContext("Toolbar");
+
+  let menuRef = null;
+
+  $: ctx.setOverflow(menuRef != null);
+  $: if (menuRef) menuRef.style.top = "100%";
+</script>
+
+<OverflowMenu
+  bind:menuRef
+  icon="{Settings16}"
+  {...$$restProps}
+  class="bx--toolbar-action bx--overflow-menu {$$restProps.class}"
+  flipped
+>
+  <slot />
+</OverflowMenu>

--- a/src/DataTable/ToolbarMenuItem.svelte
+++ b/src/DataTable/ToolbarMenuItem.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { OverflowMenuItem } from "../OverflowMenu";
+</script>
+
+<OverflowMenuItem {...$$restProps}>
+  <slot />
+</OverflowMenuItem>

--- a/src/DataTable/ToolbarMenuItem.svelte
+++ b/src/DataTable/ToolbarMenuItem.svelte
@@ -2,6 +2,6 @@
   import { OverflowMenuItem } from "../OverflowMenu";
 </script>
 
-<OverflowMenuItem {...$$restProps}>
+<OverflowMenuItem {...$$restProps} on:click on:keydown>
   <slot />
 </OverflowMenuItem>

--- a/src/DataTable/index.js
+++ b/src/DataTable/index.js
@@ -10,3 +10,5 @@ export { default as Toolbar } from "./Toolbar.svelte";
 export { default as ToolbarContent } from "./ToolbarContent.svelte";
 export { default as ToolbarSearch } from "./ToolbarSearch.svelte";
 export { default as ToolbarBatchActions } from "./ToolbarBatchActions.svelte";
+export { default as ToolbarMenu } from "./ToolbarMenu.svelte";
+export { default as ToolbarMenuItem } from "./ToolbarMenuItem.svelte";

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -53,6 +53,18 @@
    */
   export let id = "ccs-" + Math.random().toString(36);
 
+  /**
+   * Obtain a reference to the trigger button element
+   * @type {null | HTMLButtonElement} [ref=null]
+   */
+  export let buttonRef = null;
+
+  /**
+   * Obtain a reference to the overflow menu element
+   * @type {null | HTMLUListElement} [ref=null]
+   */
+  export let menuRef = null;
+
   import { createEventDispatcher, setContext, afterUpdate } from "svelte";
   import { writable } from "svelte/store";
   import OverflowMenuVertical16 from "carbon-icons-svelte/lib/OverflowMenuVertical16";
@@ -64,10 +76,8 @@
   const focusedId = writable(undefined);
   const currentIndex = writable(-1);
 
-  $: buttonRef = undefined;
-  $: buttonWidth = undefined;
-  $: menuRef = undefined;
-  $: didOpen = false;
+  let buttonWidth = undefined;
+  let didOpen = false;
 
   setContext("OverflowMenu", {
     focusedId,

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ export {
   ToolbarContent,
   ToolbarSearch,
   ToolbarBatchActions,
+  ToolbarMenu,
+  ToolbarMenuItem,
 } from "./DataTable";
 export { DataTableSkeleton } from "./DataTableSkeleton";
 export { DatePicker, DatePickerInput, DatePickerSkeleton } from "./DatePicker";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -662,6 +662,12 @@ export class ComboBox extends CarbonSvelteComponent {
      * @default null
      */
     ref?: null | HTMLInputElement;
+
+    /**
+     * Obtain a reference to the list HTML element
+     * @default null
+     */
+    listRef?: null | HTMLDivElement;
   };
 }
 
@@ -2929,6 +2935,18 @@ export class OverflowMenu extends CarbonSvelteComponent {
      * Set an id for the button element
      */
     id?: string;
+
+    /**
+     * Obtain a reference to the trigger button element
+     * @default null
+     */
+    buttonRef?: null | HTMLButtonElement;
+
+    /**
+     * Obtain a reference to the overflow menu element
+     * @default null
+     */
+    menuRef?: null | HTMLUListElement;
   };
 
   $$slot_def: { menu: {}; default: {} };
@@ -5121,6 +5139,14 @@ export class ToolbarBatchActions extends CarbonSvelteComponent {
 }
 
 export class ToolbarContent extends CarbonSvelteComponent {
+  $$slot_def: { default: {} };
+}
+
+export class ToolbarMenu extends CarbonSvelteComponent {
+  $$slot_def: { default: {} };
+}
+
+export class ToolbarMenuItem extends CarbonSvelteComponent {
   $$slot_def: { default: {} };
 }
 


### PR DESCRIPTION
#14

---

**Features**

- DataTable: add `ToolbarMenu`, `ToolbarMenuItem`

**Fixes**

- DataTable: cancelling batch selection should unselect "select all rows" checkbox
- Toolbar: remove duplicate "bx--toolbar-content" element