### PR TITLE
MultiSelect: forward "clear" event, dispatch "select" event

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2756,7 +2756,7 @@ No slots.
 
 ### Dispatched events
 
-No dispatched events.
+- `on:select`
 
 ---
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2749,6 +2749,7 @@ No slots.
 
 ### Forwarded events
 
+- `on:clear`
 - `on:keydown`
 - `on:focus`
 - `on:blur`

--- a/docs/src/PUBLIC_API.json
+++ b/docs/src/PUBLIC_API.json
@@ -8054,8 +8054,8 @@
         [
           "clear",
           {
-            "start": 8393,
-            "end": 8401,
+            "start": 8577,
+            "end": 8585,
             "type": "EventHandler",
             "name": "clear",
             "modifiers": [],
@@ -8065,8 +8065,8 @@
         [
           "keydown",
           {
-            "start": 9289,
-            "end": 9299,
+            "start": 9473,
+            "end": 9483,
             "type": "EventHandler",
             "name": "keydown",
             "modifiers": [],
@@ -8076,8 +8076,8 @@
         [
           "focus",
           {
-            "start": 9791,
-            "end": 9799,
+            "start": 9975,
+            "end": 9983,
             "type": "EventHandler",
             "name": "focus",
             "modifiers": [],
@@ -8087,8 +8087,8 @@
         [
           "blur",
           {
-            "start": 9810,
-            "end": 9817,
+            "start": 9994,
+            "end": 10001,
             "type": "EventHandler",
             "name": "blur",
             "modifiers": [],
@@ -8096,7 +8096,14 @@
           }
         ]
       ],
-      "dispatched_events": []
+      "dispatched_events": [
+        [
+          "select",
+          {
+            "detail": "{\n        selectedIds,\n        selected: checked,\n        unselected: unchecked,\n      }"
+          }
+        ]
+      ]
     },
     "NotificationActionButton": {
       "moduleName": "NotificationActionButton",

--- a/docs/src/PUBLIC_API.json
+++ b/docs/src/PUBLIC_API.json
@@ -8052,10 +8052,21 @@
       "slots": [],
       "forwarded_events": [
         [
+          "clear",
+          {
+            "start": 8393,
+            "end": 8401,
+            "type": "EventHandler",
+            "name": "clear",
+            "modifiers": [],
+            "expression": null
+          }
+        ],
+        [
           "keydown",
           {
-            "start": 9267,
-            "end": 9277,
+            "start": 9289,
+            "end": 9299,
             "type": "EventHandler",
             "name": "keydown",
             "modifiers": [],
@@ -8065,8 +8076,8 @@
         [
           "focus",
           {
-            "start": 9769,
-            "end": 9777,
+            "start": 9791,
+            "end": 9799,
             "type": "EventHandler",
             "name": "focus",
             "modifiers": [],
@@ -8076,8 +8087,8 @@
         [
           "blur",
           {
-            "start": 9788,
-            "end": 9795,
+            "start": 9810,
+            "end": 9817,
             "type": "EventHandler",
             "name": "blur",
             "modifiers": [],

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -13,6 +13,16 @@ components: ["Dropdown", "DropdownSkeleton"]
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 
+### Format item display text
+
+Use the `itemToString` prop to format the display of individual items.
+
+<Dropdown itemToString={item => {
+  return item.text + ' (' + item.id +')'
+}} titleText="Contact" selectedIndex={0} items="{[{id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}]}" />
+
 ### Light variant
 
 <Dropdown light titleText="Contact" selectedIndex={0} items="{[{id: "0", text: "Slack"},

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -10,7 +10,7 @@ By default, items will be ordered alphabetically based on the `item.text` value.
 <MultiSelect titleText="Contact" label="Select contact methods..."
     items="{[{id: "0", text: "Slack"},
     {id: "1", text: "Email"},
-    {id: "2", text: "Fax"}]}" selectedIds="{["0", "1"]}"
+    {id: "2", text: "Fax"}]}"
   />
 
 ### No alphabetical ordering
@@ -20,7 +20,32 @@ To prevent alphabetical item ordering, pass an empty function to the `sortItem` 
 <MultiSelect titleText="Contact" label="Select contact methods..."
     items="{[{id: "0", text: "Slack"},
     {id: "1", text: "Email"},
-    {id: "2", text: "Fax"}]}" selectedIds="{["0", "1"]}"
+    {id: "2", text: "Fax"}]}" 
+    sortItem="{() => {}}"
+  />
+
+### Initial selected items
+
+To select (or bind) items, pass an array of item ids to `selectedIds`.
+
+<MultiSelect selectedIds="{["0", "1"]}" titleText="Contact" label="Select contact methods..."
+    items="{[{id: "0", text: "Slack"},
+    {id: "1", text: "Email"},
+    {id: "2", text: "Fax"}]}" 
+  />
+
+
+
+### Format item display text
+
+Use the `itemToString` prop to format the display of individual items.
+
+<MultiSelect itemToString={item => {
+  return item.text + ' (' + item.id +')'
+}} titleText="Contact" label="Select contact methods..."
+    items="{[{id: "0", text: "Slack"},
+    {id: "1", text: "Email"},
+    {id: "2", text: "Fax"}]}"
     sortItem="{() => {}}"
   />
 

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -169,11 +169,10 @@
   let fieldRef = null;
   let selectionRef = null;
   let inputRef = null;
-
-  $: inputValue = "";
-  $: initialSorted = false;
-  $: highlightedIndex = -1;
-  $: prevChecked = [];
+  let inputValue = "";
+  let initialSorted = false;
+  let highlightedIndex = -1;
+  let prevChecked = [];
 
   setContext("MultiSelect", {
     declareRef: ({ key, ref }) => {
@@ -335,6 +334,7 @@
       {#if checked.length > 0}
         <ListBoxSelection
           selectionCount="{checked.length}"
+          on:clear
           on:clear="{() => {
             sortedItems = sortedItems.map((item) => ({
               ...item,

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -153,7 +153,7 @@
    * @typedef {{ id: MultiSelectItemId; text: MultiSelectItemText; }} MultiSelectItem
    */
 
-  import { afterUpdate, setContext } from "svelte";
+  import { afterUpdate, createEventDispatcher, setContext } from "svelte";
   import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16";
   import { Checkbox } from "../Checkbox";
   import {
@@ -164,6 +164,8 @@
     ListBoxMenuItem,
     ListBoxSelection,
   } from "../ListBox";
+
+  const dispatch = createEventDispatcher();
 
   let multiSelectRef = null;
   let fieldRef = null;
@@ -213,6 +215,11 @@
       }
       prevChecked = checked;
       selectedIds = checked.map(({ id }) => id);
+      dispatch("select", {
+        selectedIds,
+        selected: checked,
+        unselected: unchecked,
+      });
     }
 
     if (!open) {


### PR DESCRIPTION
**Features**

- MultiSelect: forward "clear" event
- MultiSelect: dispatch "select" event to be consistent with ComboBox, Dropdown (#378 , #344 )

Signature for "select" event:

```ts
// on:select

interface Detail {
  selectedIds: string[];
  selected: Item[];
  unselected: Item[];
}
```

**Documentation**

- Document `itemToString` prop for Dropdown, MultiSelect
- MultiSelect: add example for "Initial selected items"