### PR TITLE
CodeSnippet: showMoreLess should update if code is dynamically updated

### DIFF
--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -51,6 +51,20 @@ let comment = `
 
 <CodeSnippet wrapText type="multi" code="{comment}" />
 
+### Dynamic multi-line code
+
+For dynamically updated code, you must use the `code` prop instead of the default slot.
+
+<FileSource src="/framed/CodeSnippet/DynamicCodeSnippet" />
+
+### Hidden multi-line code
+
+There may be cases where your code snippet is visually hidden. The logic to render the "Show more" button relies on the element's computed height. For visually hidden content, the button will not appear because the height is `0`.
+
+The recommended workaround is to re-render the component. See the example below.
+
+<FileSource src="/framed/CodeSnippet/HiddenCodeSnippet" />
+
 ### Skeleton
 
 The default skeleton type is `"single"`.

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -59,7 +59,7 @@ For dynamically updated code, you must use the `code` prop instead of the defaul
 
 ### Hidden multi-line code
 
-There may be cases where your code snippet is visually hidden. The logic to render the "Show more" button relies on the element's computed height. For visually hidden content, the button will not appear because the height is `0`.
+There may be cases where your code snippet is hidden in the DOM. The logic to render the "Show more" button relies on the element's computed height. For hidden content, the button will not appear because the computed height is `0`.
 
 The recommended workaround is to re-render the component. See the example below.
 

--- a/docs/src/pages/framed/CodeSnippet/DynamicCodeSnippet.svelte
+++ b/docs/src/pages/framed/CodeSnippet/DynamicCodeSnippet.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { ToggleSmall, CodeSnippet } from "carbon-components-svelte";
+
+  let toggled = false;
+
+  $: length = toggled ? 20 : 10;
+  $: code = Array.from({ length }, (_, i) => i + 1).join("\n");
+</script>
+
+<ToggleSmall
+  style="margin-bottom: var(--cds-spacing-05)"
+  labelText="Trigger snippet overflow"
+  bind:toggled
+/>
+<CodeSnippet type="multi" code="{code}" />

--- a/docs/src/pages/framed/CodeSnippet/HiddenCodeSnippet.svelte
+++ b/docs/src/pages/framed/CodeSnippet/HiddenCodeSnippet.svelte
@@ -28,5 +28,7 @@
 {#if toggled}
   <br /><br />
   <h5>"Show more" will render</h5><br />
-  <CodeSnippet type="multi" code="{code}" />
+  <div class:hidden="{!toggled}">
+    <CodeSnippet type="multi" code="{code}" />
+  </div>
 {/if}

--- a/docs/src/pages/framed/CodeSnippet/HiddenCodeSnippet.svelte
+++ b/docs/src/pages/framed/CodeSnippet/HiddenCodeSnippet.svelte
@@ -1,38 +1,32 @@
 <script>
-  import { CodeSnippet, Tabs, Tab, TabContent } from "carbon-components-svelte";
+  import { ToggleSmall, CodeSnippet } from "carbon-components-svelte";
 
-  let selected = 0;
+  let toggled = false;
 
   const code = Array.from({ length: 20 }, (_, i) => i + 1).join("\n");
 </script>
 
 <style>
-  p {
-    margin-bottom: var(--cds-spacing-05);
+  .hidden {
+    display: none;
   }
 </style>
 
-<Tabs bind:selected>
-  <Tab label="Tab 1" />
-  <Tab label="Tab 2" />
-  <div slot="content">
-    <TabContent>
-      <p>Tab 2 contains a multi-line code snippet.</p>
-      <p>
-        Inactive tab content is visually hidden but still rendered in the DOM.
-        As a result, the "Show more" button will not appear because the computed
-        height of the code element is 0.
-      </p>
-      <p>
-        To work around this, you can force the code snippet to be re-rendered
-        when the tab content is active.
-      </p>
-    </TabContent>
-    <TabContent>
-      <p>The "Show more" button should appear.</p>
-      {#if selected === 1}
-        <CodeSnippet type="multi" code="{code}" />
-      {/if}
-    </TabContent>
-  </div>
-</Tabs>
+<ToggleSmall
+  style="margin-bottom: var(--cds-spacing-05)"
+  labelText="Show code snippets"
+  bind:toggled
+/>
+
+{#if toggled}
+  <h5>"Show more" will not render</h5><br />
+{/if}
+<div class:hidden="{!toggled}">
+  <CodeSnippet type="multi" code="{code}" />
+</div>
+
+{#if toggled}
+  <br /><br />
+  <h5>"Show more" will render</h5><br />
+  <CodeSnippet type="multi" code="{code}" />
+{/if}

--- a/docs/src/pages/framed/CodeSnippet/HiddenCodeSnippet.svelte
+++ b/docs/src/pages/framed/CodeSnippet/HiddenCodeSnippet.svelte
@@ -1,0 +1,38 @@
+<script>
+  import { CodeSnippet, Tabs, Tab, TabContent } from "carbon-components-svelte";
+
+  let selected = 0;
+
+  const code = Array.from({ length: 20 }, (_, i) => i + 1).join("\n");
+</script>
+
+<style>
+  p {
+    margin-bottom: var(--cds-spacing-05);
+  }
+</style>
+
+<Tabs bind:selected>
+  <Tab label="Tab 1" />
+  <Tab label="Tab 2" />
+  <div slot="content">
+    <TabContent>
+      <p>Tab 2 contains a multi-line code snippet.</p>
+      <p>
+        Inactive tab content is visually hidden but still rendered in the DOM.
+        As a result, the "Show more" button will not appear because the computed
+        height of the code element is 0.
+      </p>
+      <p>
+        To work around this, you can force the code snippet to be re-rendered
+        when the tab content is active.
+      </p>
+    </TabContent>
+    <TabContent>
+      <p>The "Show more" button should appear.</p>
+      {#if selected === 1}
+        <CodeSnippet type="multi" code="{code}" />
+      {/if}
+    </TabContent>
+  </div>
+</Tabs>

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -99,15 +99,22 @@
    */
   export let ref = null;
 
+  import { tick } from "svelte";
   import ChevronDown16 from "carbon-icons-svelte/lib/ChevronDown16";
   import { Button } from "../Button";
   import { Copy } from "../Copy";
   import { CopyButton } from "../CopyButton";
   import CodeSnippetSkeleton from "./CodeSnippet.Skeleton.svelte";
 
+  function setShowMoreLess() {
+    const { height } = ref.getBoundingClientRect();
+    if (height > 0) showMoreLess = ref.getBoundingClientRect().height > 255;
+  }
+
   $: expandText = expanded ? showLessText : showMoreText;
   $: if (type === "multi" && ref) {
-    showMoreLess = ref.getBoundingClientRect().height > 255;
+    if (code === undefined) setShowMoreLess();
+    if (code) tick().then(setShowMoreLess);
   }
 </script>
 


### PR DESCRIPTION
**Fixes**

- CodeSnippet: `showMoreLess` should be re-computed if `code` is dynamically updated

**Documentation**

- CodeSnippet: add example for dynamically updating `code`
- CodeSnippet: add example for "Hidden code snippet" edge case (#373)