### PR TITLE
Remove bx--body--with-modal-open from body only when there are no visible modals

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -83,7 +83,9 @@
   });
 
   onDestroy(() => {
-    document.body.classList.remove("bx--body--with-modal-open");
+    if(document.querySelectorAll('.bx--modal.is-visible').length === 0) {
+      document.body.classList.remove("bx--body--with-modal-open");
+    }
   });
 
   afterUpdate(() => {
@@ -91,7 +93,9 @@
       if (!open) {
         opened = false;
         dispatch("close");
-        document.body.classList.remove("bx--body--with-modal-open");
+        if(document.querySelectorAll('.bx--modal.is-visible').length === 0) {
+          document.body.classList.remove("bx--body--with-modal-open");
+        }
       }
     } else if (open) {
       opened = true;

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -132,7 +132,9 @@
 
   onMount(() => {
     return () => {
-      document.body.classList.remove("bx--body--with-modal-open");
+      if(document.querySelectorAll('.bx--modal.is-visible').length === 0) {
+        document.body.classList.remove("bx--body--with-modal-open");
+      }
     };
   });
 
@@ -141,7 +143,9 @@
       if (!open) {
         opened = false;
         dispatch("close");
-        document.body.classList.remove("bx--body--with-modal-open");
+        if(document.querySelectorAll('.bx--modal.is-visible').length === 0) {
+            document.body.classList.remove("bx--body--with-modal-open");
+        }
       }
     } else if (open) {
       opened = true;


### PR DESCRIPTION
If multiple modals are used, this correctly handles the cleanup after the modals close.
