### PR TITLE
feat(ComposedModal): allow using null for selectorPrimaryFocus to disable auto focus

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -69,7 +69,7 @@
   });
 
   function focus(element) {
-    if(selectorPrimaryFocus === null) {
+    if(selectorPrimaryFocus == null) {
       return
     }
     const node =

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -69,6 +69,9 @@
   });
 
   function focus(element) {
+    if(selectorPrimaryFocus === null) {
+      return
+    }
     const node =
       (element || innerModal).querySelector(selectorPrimaryFocus) || buttonRef;
     if (node != null) node.focus();


### PR DESCRIPTION
Useful if you want to handle the focusing yourself or do not want the modal to auto focus on anything at all after mounting.
If you don't pass the prop `selectorPrimaryFocus`, everything works as before, the modal will focus on the primary button (`buttonRef`) after mounting.
If you pass a string value to the `selectorPrimaryFocus`, the modal will focus on the value using `querySelector` after mounting.
If you now pass `selectorPrimaryFocus={null}`, the modal will not focus on anything after mounting.