### PR TITLE
feat(UIShell): add persistentHamburgerMenu prop to Header

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -37,3 +37,7 @@ components: ["Header",
 ### Header with utilities
 
 <FileSource src="/framed/UIShell/HeaderUtilities" />
+
+### Header with persisted hamburger menu
+
+<FileSource src="/framed/UIShell/PersistedHamburgerMenu" />

--- a/docs/src/pages/framed/UIShell/HeaderNav.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNav.svelte
@@ -19,7 +19,12 @@
   let isSideNavOpen = false;
 </script>
 
-<Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
+<Header
+  persistentHamburgerMenu="{true}"
+  company="IBM"
+  platformName="Carbon Svelte"
+  bind:isSideNavOpen
+>
   <div slot="skip-to-content">
     <SkipToContent />
   </div>

--- a/docs/src/pages/framed/UIShell/PersistedHamburgerMenu.svelte
+++ b/docs/src/pages/framed/UIShell/PersistedHamburgerMenu.svelte
@@ -19,7 +19,12 @@
   let isSideNavOpen = false;
 </script>
 
-<Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
+<Header
+  persistentHamburgerMenu="{true}"
+  company="IBM"
+  platformName="Carbon Svelte"
+  bind:isSideNavOpen
+>
   <div slot="skip-to-content">
     <SkipToContent />
   </div>

--- a/src/UIShell/GlobalHeader/Header.svelte
+++ b/src/UIShell/GlobalHeader/Header.svelte
@@ -37,6 +37,12 @@
   export let platformName = "";
 
   /**
+   * Specify Hamburger Menu persistance
+   * @type {boolean} [persistentHamburgerMenu=false]
+   */
+  export let persistentHamburgerMenu = false;
+
+  /**
    * Obtain a reference to the HTML anchor element
    * @type {null | HTMLAnchorElement} [ref=null]
    */
@@ -46,7 +52,8 @@
 
   let winWidth = undefined;
 
-  $: isSideNavOpen = expandedByDefault && winWidth >= 1056;
+  $: isSideNavOpen =
+    expandedByDefault && winWidth >= 1056 && persistentHamburgerMenu !== true;
   $: ariaLabel = company
     ? `${company} `
     : "" + (uiShellAriaLabel || $$props["aria-label"] || platformName);
@@ -56,7 +63,7 @@
 
 <header role="banner" aria-label="{ariaLabel}" class:bx--header="{true}">
   <slot name="skip-to-content" />
-  {#if winWidth < 1056}
+  {#if winWidth < 1056 || persistentHamburgerMenu === true}
     <HamburgerMenu bind:isOpen="{isSideNavOpen}" />
   {/if}
   <a

--- a/src/UIShell/GlobalHeader/Header.svelte
+++ b/src/UIShell/GlobalHeader/Header.svelte
@@ -53,7 +53,7 @@
   let winWidth = undefined;
 
   $: isSideNavOpen =
-    expandedByDefault && winWidth >= 1056 && persistentHamburgerMenu !== true;
+    expandedByDefault && winWidth >= 1056 && !persistentHamburgerMenu;
   $: ariaLabel = company
     ? `${company} `
     : "" + (uiShellAriaLabel || $$props["aria-label"] || platformName);
@@ -63,7 +63,7 @@
 
 <header role="banner" aria-label="{ariaLabel}" class:bx--header="{true}">
   <slot name="skip-to-content" />
-  {#if winWidth < 1056 || persistentHamburgerMenu === true}
+  {#if winWidth < 1056 || persistentHamburgerMenu}
     <HamburgerMenu bind:isOpen="{isSideNavOpen}" />
   {/if}
   <a

--- a/src/UIShell/SideNav/SideNav.svelte
+++ b/src/UIShell/SideNav/SideNav.svelte
@@ -33,7 +33,7 @@
   class:bx--side-nav="{true}"
   class:bx--side-nav--ux="{true}"
   class:bx--side-nav--expanded="{isOpen}"
-  class:bx--side-nav--collapsed="{!isOpen && !fixed}"
+  class:bx--side-nav--collapsed="{fixed ? !isOpen && fixed : !isOpen}"
   {...$$restProps}
 >
   <slot />

--- a/src/UIShell/SideNav/SideNav.svelte
+++ b/src/UIShell/SideNav/SideNav.svelte
@@ -33,7 +33,7 @@
   class:bx--side-nav="{true}"
   class:bx--side-nav--ux="{true}"
   class:bx--side-nav--expanded="{isOpen}"
-  class:bx--side-nav--collapsed="{fixed ? !isOpen && fixed : !isOpen}"
+  class:bx--side-nav--collapsed="{!isOpen}"
   {...$$restProps}
 >
   <slot />

--- a/src/UIShell/SideNav/SideNav.svelte
+++ b/src/UIShell/SideNav/SideNav.svelte
@@ -33,7 +33,7 @@
   class:bx--side-nav="{true}"
   class:bx--side-nav--ux="{true}"
   class:bx--side-nav--expanded="{isOpen}"
-  class:bx--side-nav--collapsed="{!isOpen && fixed}"
+  class:bx--side-nav--collapsed="{!isOpen && !fixed}"
   {...$$restProps}
 >
   <slot />


### PR DESCRIPTION
- adds `persistentHamburgerMenu` prop to Header component
- fixes collapse logic in SideNav
- overrides `isSideNavOpen` logic when persisting hamburger menu

ref #374 