### PR TITLE
feat(toggle): support small size, deprecate ToggleSmall

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3863,15 +3863,16 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value                                    | Description                                     |
-| :-------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| toggled   | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to toggle the checkbox input      |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable checkbox input         |
-| labelA    | <code>let</code> | No       | <code>string</code>  | <code>"Off"</code>                               | Specify the label for the untoggled state       |
-| labelB    | <code>let</code> | No       | <code>string</code>  | <code>"On"</code>                                | Specify the label for the toggled state         |
-| labelText | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the label text                          |
-| id        | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
-| name      | <code>let</code> | No       | <code>string</code>  | --                                               | Specify a name attribute for the checkbox input |
+| Prop name | Kind             | Reactive | Type                               | Default value                                    | Description                                     |
+| :-------- | :--------------- | :------- | :--------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| toggled   | <code>let</code> | Yes      | <code>boolean</code>               | <code>false</code>                               | Set to `true` to toggle the checkbox input      |
+| size      | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size                         |
+| disabled  | <code>let</code> | No       | <code>boolean</code>               | <code>false</code>                               | Set to `true` to disable checkbox input         |
+| labelA    | <code>let</code> | No       | <code>string</code>                | <code>"Off"</code>                               | Specify the label for the untoggled state       |
+| labelB    | <code>let</code> | No       | <code>string</code>                | <code>"On"</code>                                | Specify the label for the toggled state         |
+| labelText | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text                          |
+| id        | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
+| name      | <code>let</code> | No       | <code>string</code>                | --                                               | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -3894,10 +3895,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value                                    | Description                     |
-| :-------- | :--------------- | :------- | :------------------ | ------------------------------------------------ | ------------------------------- |
-| labelText | <code>let</code> | No       | <code>string</code> | <code>""</code>                                  | Specify the label text          |
-| id        | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element |
+| Prop name | Kind             | Reactive | Type                               | Default value                                    | Description                     |
+| :-------- | :--------------- | :------- | :--------------------------------- | ------------------------------------------------ | ------------------------------- |
+| size      | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size         |
+| labelText | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text          |
+| id        | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8957,6 +8957,16 @@
       "filePath": "/src/Toggle/Toggle.svelte",
       "props": [
         {
+          "name": "size",
+          "kind": "let",
+          "description": "Specify the toggle size",
+          "type": "\"default\" | \"sm\"",
+          "value": "\"default\"",
+          "isFunction": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "toggled",
           "kind": "let",
           "description": "Set to `true` to toggle the checkbox input",
@@ -9044,6 +9054,16 @@
       "moduleName": "ToggleSkeleton",
       "filePath": "/src/Toggle/ToggleSkeleton.svelte",
       "props": [
+        {
+          "name": "size",
+          "kind": "let",
+          "description": "Specify the toggle size",
+          "type": "\"default\" | \"sm\"",
+          "value": "\"default\"",
+          "isFunction": false,
+          "constant": false,
+          "reactive": false
+        },
         {
           "name": "labelText",
           "kind": "let",

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -27,7 +27,7 @@ let comment = `
 `
 </script>
 
-<InlineNotification svx-ignore lowContrast title="Note:" subtitle="By design, the copy button does not copy text to the clipboard. You will need to write your own logic." kind="info" hideCloseButton />
+<InlineNotification svx-ignore title="Note:" subtitle="By design, the copy button does not copy text to the clipboard. You will need to write your own logic." kind="info" hideCloseButton />
 
 ### Default (single-line)
 

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -3,7 +3,7 @@
   import Preview from "../../components/Preview.svelte";
 </script>
 
-<InlineNotification svx-ignore lowContrast title="Note:" subtitle="By design, the copy button does not copy text to the clipboard. You will need to write your own logic." kind="info" hideCloseButton />
+<InlineNotification svx-ignore title="Note:" subtitle="By design, the copy button does not copy text to the clipboard. You will need to write your own logic." kind="info" hideCloseButton />
 
 ### Default
 

--- a/docs/src/pages/components/Toggle.svx
+++ b/docs/src/pages/components/Toggle.svx
@@ -23,6 +23,14 @@ components: ["Toggle", "ToggleSkeleton"]
 
 <Toggle labelText="Push notifications" disabled />
 
+### Small size
+
+<Toggle size="sm" labelText="Push notifications" />
+
 ### Skeleton
 
 <ToggleSkeleton />
+
+### Skeleton (small)
+
+<ToggleSkeleton size="sm" />

--- a/docs/src/pages/components/ToggleSmall.svx
+++ b/docs/src/pages/components/ToggleSmall.svx
@@ -3,9 +3,15 @@ components: ["ToggleSmall", "ToggleSmallSkeleton"]
 ---
 
 <script>
-  import { ToggleSmall, ToggleSmallSkeleton } from "carbon-components-svelte";
+  import { ToggleSmall, ToggleSmallSkeleton, InlineNotification, Link } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
 </script>
+
+<InlineNotification svx-ignore title="Deprecation warning" kind="warning" hideCloseButton>
+  <div>
+    This component will be removed in version 1.0.0. Use the <Link href="/components/Toggle#small-size">Toggle small variant</Link> instead.
+  </div>
+</InlineNotification>
 
 ### Default (untoggled)
 

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -1,4 +1,10 @@
 <script>
+  /**
+   * Specify the toggle size
+   * @type {"default" | "sm"}
+   */
+  export let size = "default";
+
   /** Set to `true` to toggle the checkbox input */
   export let toggled = false;
 
@@ -35,6 +41,7 @@
   <input
     type="checkbox"
     class:bx--toggle-input="{true}"
+    class:bx--toggle-input--small="{size === 'sm'}"
     checked="{toggled}"
     on:change
     on:change="{() => {

--- a/src/Toggle/ToggleSkeleton.svelte
+++ b/src/Toggle/ToggleSkeleton.svelte
@@ -1,4 +1,10 @@
 <script>
+  /**
+   * Specify the toggle size
+   * @type {"default" | "sm"}
+   */
+  export let size = "default";
+
   /** Specify the label text */
   export let labelText = "";
 
@@ -18,6 +24,7 @@
     type="checkbox"
     id="{id}"
     class:bx--toggle="{true}"
+    class:bx--toggle--small="{size === 'sm'}"
     class:bx--skeleton="{true}"
   />
   <label

--- a/src/ToggleSmall/ToggleSmall.svelte
+++ b/src/ToggleSmall/ToggleSmall.svelte
@@ -1,4 +1,10 @@
 <script>
+  /**
+   * @deprecated
+   * This component will be removed in version 1.0.0.
+   * Use `<Toggle size="sm" />` instead
+   */
+
   /** Set to `true` to toggle the checkbox input */
   export let toggled = false;
 

--- a/src/ToggleSmall/ToggleSmallSkeleton.svelte
+++ b/src/ToggleSmall/ToggleSmallSkeleton.svelte
@@ -1,4 +1,10 @@
 <script>
+  /**
+   * @deprecated
+   * This component will be removed in version 1.0.0.
+   * Use `<ToggleSkeleton size="sm" />` instead
+   */
+
   /** Specify the label text */
   export let labelText = "";
 

--- a/types/Toggle/Toggle.d.ts
+++ b/types/Toggle/Toggle.d.ts
@@ -2,6 +2,12 @@
 
 export interface ToggleProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
+   * Specify the toggle size
+   * @default "default"
+   */
+  size?: "default" | "sm";
+
+  /**
    * Set to `true` to toggle the checkbox input
    * @default false
    */

--- a/types/Toggle/ToggleSkeleton.d.ts
+++ b/types/Toggle/ToggleSkeleton.d.ts
@@ -2,6 +2,12 @@
 
 export interface ToggleSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
+   * Specify the toggle size
+   * @default "default"
+   */
+  size?: "default" | "sm";
+
+  /**
    * Specify the label text
    * @default ""
    */


### PR DESCRIPTION
This PR addresses a suggestion from @ispyinternet to fold `ToggleSmall` into `Toggle` because the components are virtually identical. This has also been raised upstream in https://github.com/carbon-design-system/carbon/issues/6653

**Changes**

- add "size" prop to `Toggle` and `ToggleSkeleton`; default value is "default" while "sm" uses the small variant
- add deprecation notices to `ToggleSmall` and `ToggleSmallSkeleton`

**Breaking Changes**

None.

However, the `ToggleSmall` and `ToggleSmallSkeleton` will be removed in the next major version.