### PR TITLE
refactor(button): remove redundant if statement

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -135,14 +135,12 @@
         <span class:bx--assistive-text="{true}">{iconDescription}</span>
       {/if}
       <slot />
-      {#if icon}
-        <svelte:component
-          this="{icon}"
-          aria-hidden="true"
-          class="bx--btn__icon"
-          aria-label="{iconDescription}"
-        />
-      {/if}
+      <svelte:component
+        this="{icon}"
+        aria-hidden="true"
+        class="bx--btn__icon"
+        aria-label="{iconDescription}"
+      />
     </a>
   {:else}
     <button
@@ -157,14 +155,12 @@
         <span class:bx--assistive-text="{true}">{iconDescription}</span>
       {/if}
       <slot />
-      {#if icon}
-        <svelte:component
-          this="{icon}"
-          aria-hidden="true"
-          class="bx--btn__icon"
-          aria-label="{iconDescription}"
-        />
-      {/if}
+      <svelte:component
+        this="{icon}"
+        aria-hidden="true"
+        class="bx--btn__icon"
+        aria-label="{iconDescription}"
+      />
     </button>
   {/if}
 {/if}


### PR DESCRIPTION
The `#if icon` conditional is redundant because svelte:component will not render if `this={icon}` is falsy.