### PR TITLE
fix(RadioButtonGroup): trigger change event

### DIFF
--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -52,10 +52,10 @@
     $selectedValue = selected
   })
 
-  $: $selectedValue, (() => {
-    selected = $selectedValue
+  selectedValue.subscribe(value => {
+    selected = value
+    dispatch("change", value);
   })
-  $: dispatch("change", $selectedValue);
 </script>
 
 <div


### PR DESCRIPTION
After the previous modifications per #407, the change event would not be dispatched when selecting a radio button. This fixes it.

There is however a slight annoyance: the change event is triggered once after the component is created. This also happened before the previous modifications #407. I tried to fix it in a few ways (for example moving the newly added `subscribe` in the `onMount` function) but to no avail :(