### PR TITLE
Use the SvelteComponent interface for typing components

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "rollup": "^2.33.3",
     "rollup-plugin-svelte": "^6.1.1",
     "rollup-plugin-terser": "^7.0.2",
-    "sveld": "^0.3.0",
-    "svelte": "^3.29.7",
-    "svelte-check": "^1.1.15",
+    "sveld": "^0.4.2",
+    "svelte": "^3.30.0",
+    "svelte-check": "^1.1.17",
     "svelte-loader": "^2.13.6",
     "typescript": "^4.1.2"
   },

--- a/types/Accordion/Accordion.d.ts
+++ b/types/Accordion/Accordion.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 import { AccordionSkeletonProps } from "./AccordionSkeleton";
 
 export interface AccordionProps extends AccordionSkeletonProps {
@@ -26,15 +27,13 @@ export interface AccordionProps extends AccordionSkeletonProps {
   skeleton?: boolean;
 }
 
-export default class Accordion {
-  $$prop_def: AccordionProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Accordion extends SvelteComponent<
+  AccordionProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Accordion/AccordionItem.d.ts
+++ b/types/Accordion/AccordionItem.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface AccordionItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
   /**
@@ -27,18 +28,15 @@ export interface AccordionItemProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   iconDescription?: string;
 }
 
-export default class AccordionItem {
-  $$prop_def: AccordionItemProps;
-  $$slot_def: {
-    default: {};
-    title: {};
-  };
-
-  $on(eventname: "animationend", cb: (event: WindowEventMap["animationend"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class AccordionItem extends SvelteComponent<
+  AccordionItemProps,
+  {
+    animationend: WindowEventMap["animationend"];
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keydown: WindowEventMap["keydown"];
+  },
+  { default: {}; title: {} }
+> {}

--- a/types/Accordion/AccordionSkeleton.d.ts
+++ b/types/Accordion/AccordionSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface AccordionSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {
   /**
@@ -25,13 +26,13 @@ export interface AccordionSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEl
   open?: boolean;
 }
 
-export default class AccordionSkeleton {
-  $$prop_def: AccordionSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class AccordionSkeleton extends SvelteComponent<
+  AccordionSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/AspectRatio/AspectRatio.d.ts
+++ b/types/AspectRatio/AspectRatio.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface AspectRatioProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,11 +9,4 @@ export interface AspectRatioProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   ratio?: "2x1" | "16x9" | "4x3" | "1x1" | "3x4" | "9x16" | "1x2";
 }
 
-export default class AspectRatio {
-  $$prop_def: AspectRatioProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class AspectRatio extends SvelteComponent<AspectRatioProps, {}, { default: {} }> {}

--- a/types/Breadcrumb/Breadcrumb.d.ts
+++ b/types/Breadcrumb/Breadcrumb.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 import { BreadcrumbSkeletonProps } from "./BreadcrumbSkeleton";
 
 export interface BreadcrumbProps extends BreadcrumbSkeletonProps {
@@ -15,15 +16,13 @@ export interface BreadcrumbProps extends BreadcrumbSkeletonProps {
   skeleton?: boolean;
 }
 
-export default class Breadcrumb {
-  $$prop_def: BreadcrumbProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Breadcrumb extends SvelteComponent<
+  BreadcrumbProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Breadcrumb/BreadcrumbItem.d.ts
+++ b/types/Breadcrumb/BreadcrumbItem.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface BreadcrumbItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
   /**
@@ -13,15 +14,13 @@ export interface BreadcrumbItemProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   isCurrentPage?: boolean;
 }
 
-export default class BreadcrumbItem {
-  $$prop_def: BreadcrumbItemProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class BreadcrumbItem extends SvelteComponent<
+  BreadcrumbItemProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Breadcrumb/BreadcrumbSkeleton.d.ts
+++ b/types/Breadcrumb/BreadcrumbSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface BreadcrumbSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -14,13 +15,13 @@ export interface BreadcrumbSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLE
   count?: number;
 }
 
-export default class BreadcrumbSkeleton {
-  $$prop_def: BreadcrumbSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class BreadcrumbSkeleton extends SvelteComponent<
+  BreadcrumbSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Button/Button.d.ts
+++ b/types/Button/Button.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 import { ButtonSkeletonProps } from "./ButtonSkeleton";
 
 export interface ButtonProps
@@ -88,9 +89,15 @@ export interface ButtonProps
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
 }
 
-export default class Button {
-  $$prop_def: ButtonProps;
-  $$slot_def: {
+export default class Button extends SvelteComponent<
+  ButtonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {
     default: {
       props: {
         role: "button";
@@ -102,11 +109,5 @@ export default class Button {
         [key: string]: any;
       };
     };
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+  }
+> {}

--- a/types/Button/ButtonSet.d.ts
+++ b/types/Button/ButtonSet.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ButtonSetProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,11 +9,4 @@ export interface ButtonSetProps extends svelte.JSX.HTMLAttributes<HTMLElementTag
   stacked?: boolean;
 }
 
-export default class ButtonSet {
-  $$prop_def: ButtonSetProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ButtonSet extends SvelteComponent<ButtonSetProps, {}, { default: {} }> {}

--- a/types/Button/ButtonSkeleton.d.ts
+++ b/types/Button/ButtonSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ButtonSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -19,13 +20,13 @@ export interface ButtonSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   small?: boolean;
 }
 
-export default class ButtonSkeleton {
-  $$prop_def: ButtonSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ButtonSkeleton extends SvelteComponent<
+  ButtonSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Checkbox/Checkbox.d.ts
+++ b/types/Checkbox/Checkbox.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface CheckboxProps {
   /**
@@ -67,15 +68,15 @@ export interface CheckboxProps {
   ref?: null | HTMLInputElement;
 }
 
-export default class Checkbox {
-  $$prop_def: CheckboxProps;
-  $$slot_def: {};
-
-  $on(eventname: "check", cb: (event: CustomEvent<boolean>) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Checkbox extends SvelteComponent<
+  CheckboxProps,
+  {
+    check: CustomEvent<boolean>;
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+  },
+  {}
+> {}

--- a/types/Checkbox/CheckboxSkeleton.d.ts
+++ b/types/Checkbox/CheckboxSkeleton.d.ts
@@ -1,14 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface CheckboxSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
 
-export default class CheckboxSkeleton {
-  $$prop_def: CheckboxSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class CheckboxSkeleton extends SvelteComponent<
+  CheckboxSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/CodeSnippet/CodeSnippet.d.ts
+++ b/types/CodeSnippet/CodeSnippet.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface CodeSnippetProps {
   /**
@@ -99,16 +100,14 @@ export interface CodeSnippetProps {
   ref?: null | HTMLPreElement;
 }
 
-export default class CodeSnippet {
-  $$prop_def: CodeSnippetProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "animationend", cb: (event: WindowEventMap["animationend"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class CodeSnippet extends SvelteComponent<
+  CodeSnippetProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    animationend: WindowEventMap["animationend"];
+  },
+  { default: {} }
+> {}

--- a/types/CodeSnippet/CodeSnippetSkeleton.d.ts
+++ b/types/CodeSnippet/CodeSnippetSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface CodeSnippetSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface CodeSnippetSkeletonProps extends svelte.JSX.HTMLAttributes<HTML
   type?: "single" | "inline" | "multi";
 }
 
-export default class CodeSnippetSkeleton {
-  $$prop_def: CodeSnippetSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class CodeSnippetSkeleton extends SvelteComponent<
+  CodeSnippetSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/ComboBox/ComboBox.d.ts
+++ b/types/ComboBox/ComboBox.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ComboBoxItem {
   id: string;
@@ -118,18 +119,15 @@ export interface ComboBoxProps extends svelte.JSX.HTMLAttributes<HTMLElementTagN
   listRef?: null | HTMLDivElement;
 }
 
-export default class ComboBox {
-  $$prop_def: ComboBoxProps;
-  $$slot_def: {};
-
-  $on(
-    eventname: "select",
-    cb: (event: CustomEvent<{ selectedId: string; selectedIndex: number; selectedItem: ComboBoxItem }>) => void
-  ): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: "clear", cb: (event: WindowEventMap["clear"]) => void): () => void;
-  $on(eventname: "scroll", cb: (event: WindowEventMap["scroll"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ComboBox extends SvelteComponent<
+  ComboBoxProps,
+  {
+    select: CustomEvent<{ selectedId: string; selectedIndex: number; selectedItem: ComboBoxItem }>;
+    keydown: WindowEventMap["keydown"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+    clear: WindowEventMap["clear"];
+    scroll: WindowEventMap["scroll"];
+  },
+  {}
+> {}

--- a/types/ComposedModal/ComposedModal.d.ts
+++ b/types/ComposedModal/ComposedModal.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ComposedModalProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -43,19 +44,17 @@ export interface ComposedModalProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   ref?: null | HTMLDivElement;
 }
 
-export default class ComposedModal {
-  $$prop_def: ComposedModalProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "transitionend", cb: (event: WindowEventMap["transitionend"]) => void): () => void;
-  $on(eventname: "submit", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: "close", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: "open", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ComposedModal extends SvelteComponent<
+  ComposedModalProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    transitionend: WindowEventMap["transitionend"];
+    submit: CustomEvent<any>;
+    close: CustomEvent<any>;
+    open: CustomEvent<any>;
+  },
+  { default: {} }
+> {}

--- a/types/ComposedModal/ModalBody.d.ts
+++ b/types/ComposedModal/ModalBody.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ModalBodyProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -14,11 +15,4 @@ export interface ModalBodyProps extends svelte.JSX.HTMLAttributes<HTMLElementTag
   hasScrollingContent?: boolean;
 }
 
-export default class ModalBody {
-  $$prop_def: ModalBodyProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ModalBody extends SvelteComponent<ModalBodyProps, {}, { default: {} }> {}

--- a/types/ComposedModal/ModalFooter.d.ts
+++ b/types/ComposedModal/ModalFooter.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ModalFooterProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -36,11 +37,4 @@ export interface ModalFooterProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   danger?: boolean;
 }
 
-export default class ModalFooter {
-  $$prop_def: ModalFooterProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ModalFooter extends SvelteComponent<ModalFooterProps, {}, { default: {} }> {}

--- a/types/ComposedModal/ModalHeader.d.ts
+++ b/types/ComposedModal/ModalHeader.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ModalHeaderProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -44,12 +45,8 @@ export interface ModalHeaderProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   iconDescription?: string;
 }
 
-export default class ModalHeader {
-  $$prop_def: ModalHeaderProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ModalHeader extends SvelteComponent<
+  ModalHeaderProps,
+  { click: WindowEventMap["click"] },
+  { default: {} }
+> {}

--- a/types/ContentSwitcher/ContentSwitcher.d.ts
+++ b/types/ContentSwitcher/ContentSwitcher.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ContentSwitcherProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -19,16 +20,14 @@ export interface ContentSwitcherProps extends svelte.JSX.HTMLAttributes<HTMLElem
   size?: "sm" | "xl";
 }
 
-export default class ContentSwitcher {
-  $$prop_def: ContentSwitcherProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "change", cb: (event: CustomEvent<number>) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ContentSwitcher extends SvelteComponent<
+  ContentSwitcherProps,
+  {
+    change: CustomEvent<number>;
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/ContentSwitcher/Switch.d.ts
+++ b/types/ContentSwitcher/Switch.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SwitchProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -33,16 +34,14 @@ export interface SwitchProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNam
   ref?: null | HTMLButtonElement;
 }
 
-export default class Switch {
-  $$prop_def: SwitchProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Switch extends SvelteComponent<
+  SwitchProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keydown: WindowEventMap["keydown"];
+  },
+  { default: {} }
+> {}

--- a/types/Copy/Copy.d.ts
+++ b/types/Copy/Copy.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface CopyProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -20,13 +21,8 @@ export interface CopyProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameM
   ref?: null | HTMLButtonElement;
 }
 
-export default class Copy {
-  $$prop_def: CopyProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "animationend", cb: (event: WindowEventMap["animationend"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Copy extends SvelteComponent<
+  CopyProps,
+  { click: WindowEventMap["click"]; animationend: WindowEventMap["animationend"] },
+  { default: {} }
+> {}

--- a/types/CopyButton/CopyButton.d.ts
+++ b/types/CopyButton/CopyButton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 import { CopyProps } from "../Copy/Copy";
 
 export interface CopyButtonProps extends CopyProps {
@@ -9,11 +10,8 @@ export interface CopyButtonProps extends CopyProps {
   iconDescription?: string;
 }
 
-export default class CopyButton {
-  $$prop_def: CopyButtonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "animationend", cb: (event: WindowEventMap["animationend"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class CopyButton extends SvelteComponent<
+  CopyButtonProps,
+  { click: WindowEventMap["click"]; animationend: WindowEventMap["animationend"] },
+  {}
+> {}

--- a/types/DataTable/DataTable.d.ts
+++ b/types/DataTable/DataTable.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type DataTableKey = string;
 
@@ -125,31 +126,22 @@ export interface DataTableProps {
   stickyHeader?: boolean;
 }
 
-export default class DataTable {
-  $$prop_def: DataTableProps;
-  $$slot_def: {
+export default class DataTable extends SvelteComponent<
+  DataTableProps,
+  {
+    click: CustomEvent<{ header?: DataTableHeader; row?: DataTableRow; cell?: DataTableCell }>;
+    ["click:header--expand"]: CustomEvent<{ expanded: boolean }>;
+    ["click:header"]: CustomEvent<{ header: DataTableHeader; sortDirection: "ascending" | "descending" | "none" }>;
+    ["click:row"]: CustomEvent<DataTableRow>;
+    ["mouseenter:row"]: CustomEvent<DataTableRow>;
+    ["mouseleave:row"]: CustomEvent<DataTableRow>;
+    ["click:row--expand"]: CustomEvent<{ expanded: boolean; row: DataTableRow }>;
+    ["click:cell"]: CustomEvent<DataTableCell>;
+  },
+  {
     default: {};
     cell: { row: DataTableRow; cell: DataTableCell };
     ["cell-header"]: { header: DataTableNonEmptyHeader };
     ["expanded-row"]: { row: DataTableRow };
-  };
-
-  $on(
-    eventname: "click",
-    cb: (event: CustomEvent<{ header?: DataTableHeader; row?: DataTableRow; cell?: DataTableCell }>) => void
-  ): () => void;
-  $on(eventname: "click:header--expand", cb: (event: CustomEvent<{ expanded: boolean }>) => void): () => void;
-  $on(
-    eventname: "click:header",
-    cb: (event: CustomEvent<{ header: DataTableHeader; sortDirection: "ascending" | "descending" | "none" }>) => void
-  ): () => void;
-  $on(eventname: "click:row", cb: (event: CustomEvent<DataTableRow>) => void): () => void;
-  $on(eventname: "mouseenter:row", cb: (event: CustomEvent<DataTableRow>) => void): () => void;
-  $on(eventname: "mouseleave:row", cb: (event: CustomEvent<DataTableRow>) => void): () => void;
-  $on(
-    eventname: "click:row--expand",
-    cb: (event: CustomEvent<{ expanded: boolean; row: DataTableRow }>) => void
-  ): () => void;
-  $on(eventname: "click:cell", cb: (event: CustomEvent<DataTableCell>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+  }
+> {}

--- a/types/DataTable/Table.d.ts
+++ b/types/DataTable/Table.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TableProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["section"]> {
   /**
@@ -37,11 +38,4 @@ export interface TableProps extends svelte.JSX.HTMLAttributes<HTMLElementTagName
   stickyHeader?: boolean;
 }
 
-export default class Table {
-  $$prop_def: TableProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Table extends SvelteComponent<TableProps, {}, { default: {} }> {}

--- a/types/DataTable/TableBody.d.ts
+++ b/types/DataTable/TableBody.d.ts
@@ -1,12 +1,6 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TableBodyProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tbody"]> {}
 
-export default class TableBody {
-  $$prop_def: TableBodyProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TableBody extends SvelteComponent<TableBodyProps, {}, { default: {} }> {}

--- a/types/DataTable/TableCell.d.ts
+++ b/types/DataTable/TableCell.d.ts
@@ -1,16 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TableCellProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["td"]> {}
 
-export default class TableCell {
-  $$prop_def: TableCellProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TableCell extends SvelteComponent<
+  TableCellProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/DataTable/TableContainer.d.ts
+++ b/types/DataTable/TableContainer.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TableContainerProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -20,11 +21,4 @@ export interface TableContainerProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   stickyHeader?: boolean;
 }
 
-export default class TableContainer {
-  $$prop_def: TableContainerProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TableContainer extends SvelteComponent<TableContainerProps, {}, { default: {} }> {}

--- a/types/DataTable/TableHead.d.ts
+++ b/types/DataTable/TableHead.d.ts
@@ -1,16 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TableHeadProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["thead"]> {}
 
-export default class TableHead {
-  $$prop_def: TableHeadProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TableHead extends SvelteComponent<
+  TableHeadProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/DataTable/TableHeader.d.ts
+++ b/types/DataTable/TableHeader.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TableHeaderProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["th"]> {
   /**
@@ -20,15 +21,13 @@ export interface TableHeaderProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   id?: string;
 }
 
-export default class TableHeader {
-  $$prop_def: TableHeaderProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TableHeader extends SvelteComponent<
+  TableHeaderProps,
+  {
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    click: WindowEventMap["click"];
+  },
+  { default: {} }
+> {}

--- a/types/DataTable/TableRow.d.ts
+++ b/types/DataTable/TableRow.d.ts
@@ -1,16 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TableRowProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tr"]> {}
 
-export default class TableRow {
-  $$prop_def: TableRowProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TableRow extends SvelteComponent<
+  TableRowProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/DataTable/Toolbar.d.ts
+++ b/types/DataTable/Toolbar.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToolbarProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["section"]> {
   /**
@@ -8,11 +9,4 @@ export interface ToolbarProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNa
   size?: "sm" | "default";
 }
 
-export default class Toolbar {
-  $$prop_def: ToolbarProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Toolbar extends SvelteComponent<ToolbarProps, {}, { default: {} }> {}

--- a/types/DataTable/ToolbarBatchActions.d.ts
+++ b/types/DataTable/ToolbarBatchActions.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToolbarBatchActionsProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,11 +9,4 @@ export interface ToolbarBatchActionsProps extends svelte.JSX.HTMLAttributes<HTML
   formatTotalSelected?: (totalSelected: number) => string;
 }
 
-export default class ToolbarBatchActions {
-  $$prop_def: ToolbarBatchActionsProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToolbarBatchActions extends SvelteComponent<ToolbarBatchActionsProps, {}, { default: {} }> {}

--- a/types/DataTable/ToolbarContent.d.ts
+++ b/types/DataTable/ToolbarContent.d.ts
@@ -1,12 +1,6 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToolbarContentProps {}
 
-export default class ToolbarContent {
-  $$prop_def: ToolbarContentProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToolbarContent extends SvelteComponent<ToolbarContentProps, {}, { default: {} }> {}

--- a/types/DataTable/ToolbarMenu.d.ts
+++ b/types/DataTable/ToolbarMenu.d.ts
@@ -1,13 +1,7 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 import { OverflowMenuProps } from "../OverflowMenu/OverflowMenu";
 
 export interface ToolbarMenuProps extends OverflowMenuProps {}
 
-export default class ToolbarMenu {
-  $$prop_def: ToolbarMenuProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToolbarMenu extends SvelteComponent<ToolbarMenuProps, {}, { default: {} }> {}

--- a/types/DataTable/ToolbarMenuItem.d.ts
+++ b/types/DataTable/ToolbarMenuItem.d.ts
@@ -1,15 +1,11 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 import { OverflowMenuItemProps } from "../OverflowMenu/OverflowMenuItem";
 
 export interface ToolbarMenuItemProps extends OverflowMenuItemProps {}
 
-export default class ToolbarMenuItem {
-  $$prop_def: ToolbarMenuItemProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToolbarMenuItem extends SvelteComponent<
+  ToolbarMenuItemProps,
+  { click: WindowEventMap["click"]; keydown: WindowEventMap["keydown"] },
+  { default: {} }
+> {}

--- a/types/DataTable/ToolbarSearch.d.ts
+++ b/types/DataTable/ToolbarSearch.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToolbarSearchProps {
   /**
@@ -32,13 +33,13 @@ export interface ToolbarSearchProps {
   ref?: null | HTMLInputElement;
 }
 
-export default class ToolbarSearch {
-  $$prop_def: ToolbarSearchProps;
-  $$slot_def: {};
-
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToolbarSearch extends SvelteComponent<
+  ToolbarSearchProps,
+  {
+    change: WindowEventMap["change"];
+    input: WindowEventMap["input"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
+> {}

--- a/types/DataTableSkeleton/DataTableSkeleton.d.ts
+++ b/types/DataTableSkeleton/DataTableSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface DataTableSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["table"]> {
   /**
@@ -44,13 +45,13 @@ export interface DataTableSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEl
   showToolbar?: boolean;
 }
 
-export default class DataTableSkeleton {
-  $$prop_def: DataTableSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class DataTableSkeleton extends SvelteComponent<
+  DataTableSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/DatePicker/DatePicker.d.ts
+++ b/types/DatePicker/DatePicker.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface DatePickerProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -61,16 +62,14 @@ export interface DatePickerProps extends svelte.JSX.HTMLAttributes<HTMLElementTa
   id?: string;
 }
 
-export default class DatePicker {
-  $$prop_def: DatePickerProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class DatePicker extends SvelteComponent<
+  DatePickerProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: CustomEvent<any>;
+  },
+  { default: {} }
+> {}

--- a/types/DatePicker/DatePickerInput.d.ts
+++ b/types/DatePicker/DatePickerInput.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface DatePickerInputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -78,12 +79,8 @@ export interface DatePickerInputProps extends svelte.JSX.HTMLAttributes<HTMLElem
   ref?: null | HTMLInputElement;
 }
 
-export default class DatePickerInput {
-  $$prop_def: DatePickerInputProps;
-  $$slot_def: {};
-
-  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class DatePickerInput extends SvelteComponent<
+  DatePickerInputProps,
+  { input: WindowEventMap["input"]; keydown: WindowEventMap["keydown"]; blur: WindowEventMap["blur"] },
+  {}
+> {}

--- a/types/DatePicker/DatePickerSkeleton.d.ts
+++ b/types/DatePicker/DatePickerSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface DatePickerSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -14,13 +15,13 @@ export interface DatePickerSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLE
   id?: string;
 }
 
-export default class DatePickerSkeleton {
-  $$prop_def: DatePickerSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class DatePickerSkeleton extends SvelteComponent<
+  DatePickerSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Dropdown/Dropdown.d.ts
+++ b/types/Dropdown/Dropdown.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type DropdownItemId = string;
 
@@ -115,13 +116,8 @@ export interface DropdownProps extends svelte.JSX.HTMLAttributes<HTMLElementTagN
   ref?: null | HTMLButtonElement;
 }
 
-export default class Dropdown {
-  $$prop_def: DropdownProps;
-  $$slot_def: {};
-
-  $on(
-    eventname: "select",
-    cb: (event: CustomEvent<{ selectedId: DropdownItemId; selectedIndex: number; selectedItem: DropdownItem }>) => void
-  ): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Dropdown extends SvelteComponent<
+  DropdownProps,
+  { select: CustomEvent<{ selectedId: DropdownItemId; selectedIndex: number; selectedItem: DropdownItem }> },
+  {}
+> {}

--- a/types/Dropdown/DropdownSkeleton.d.ts
+++ b/types/Dropdown/DropdownSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface DropdownSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface DropdownSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEle
   inline?: boolean;
 }
 
-export default class DropdownSkeleton {
-  $$prop_def: DropdownSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class DropdownSkeleton extends SvelteComponent<
+  DropdownSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/FileUploader/FileUploader.d.ts
+++ b/types/FileUploader/FileUploader.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type Files = string[];
 
@@ -71,17 +72,17 @@ export interface FileUploaderProps extends svelte.JSX.HTMLAttributes<HTMLElement
   name?: string;
 }
 
-export default class FileUploader {
-  $$prop_def: FileUploaderProps;
-  $$slot_def: {};
-
-  $on(eventname: "add", cb: (event: CustomEvent<Files>) => void): () => void;
-  $on(eventname: "remove", cb: (event: CustomEvent<Files>) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FileUploader extends SvelteComponent<
+  FileUploaderProps,
+  {
+    add: CustomEvent<Files>;
+    remove: CustomEvent<Files>;
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+    keydown: WindowEventMap["keydown"];
+  },
+  {}
+> {}

--- a/types/FileUploader/FileUploaderButton.d.ts
+++ b/types/FileUploader/FileUploaderButton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type Files = string[];
 
@@ -70,12 +71,8 @@ export interface FileUploaderButtonProps extends svelte.JSX.HTMLAttributes<HTMLE
   ref?: null | HTMLInputElement;
 }
 
-export default class FileUploaderButton {
-  $$prop_def: FileUploaderButtonProps;
-  $$slot_def: {};
-
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FileUploaderButton extends SvelteComponent<
+  FileUploaderButtonProps,
+  { keydown: WindowEventMap["keydown"]; change: WindowEventMap["change"]; click: WindowEventMap["click"] },
+  {}
+> {}

--- a/types/FileUploader/FileUploaderDropContainer.d.ts
+++ b/types/FileUploader/FileUploaderDropContainer.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type Files = string[];
 
@@ -65,16 +66,16 @@ export interface FileUploaderDropContainerProps extends svelte.JSX.HTMLAttribute
   ref?: null | HTMLInputElement;
 }
 
-export default class FileUploaderDropContainer {
-  $$prop_def: FileUploaderDropContainerProps;
-  $$slot_def: {};
-
-  $on(eventname: "add", cb: (event: CustomEvent<Files>) => void): () => void;
-  $on(eventname: "dragover", cb: (event: WindowEventMap["dragover"]) => void): () => void;
-  $on(eventname: "dragleave", cb: (event: WindowEventMap["dragleave"]) => void): () => void;
-  $on(eventname: "drop", cb: (event: WindowEventMap["drop"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FileUploaderDropContainer extends SvelteComponent<
+  FileUploaderDropContainerProps,
+  {
+    add: CustomEvent<Files>;
+    dragover: WindowEventMap["dragover"];
+    dragleave: WindowEventMap["dragleave"];
+    drop: WindowEventMap["drop"];
+    keydown: WindowEventMap["keydown"];
+    change: WindowEventMap["change"];
+    click: WindowEventMap["click"];
+  },
+  {}
+> {}

--- a/types/FileUploader/FileUploaderItem.d.ts
+++ b/types/FileUploader/FileUploaderItem.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface FileUploaderItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {
   /**
@@ -44,13 +45,13 @@ export interface FileUploaderItemProps extends svelte.JSX.HTMLAttributes<HTMLEle
   name?: string;
 }
 
-export default class FileUploaderItem {
-  $$prop_def: FileUploaderItemProps;
-  $$slot_def: {};
-
-  $on(eventname: "delete", cb: (event: CustomEvent<string>) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FileUploaderItem extends SvelteComponent<
+  FileUploaderItemProps,
+  {
+    delete: CustomEvent<string>;
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/FileUploader/FileUploaderSkeleton.d.ts
+++ b/types/FileUploader/FileUploaderSkeleton.d.ts
@@ -1,14 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface FileUploaderSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
 
-export default class FileUploaderSkeleton {
-  $$prop_def: FileUploaderSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FileUploaderSkeleton extends SvelteComponent<
+  FileUploaderSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/FileUploader/Filename.d.ts
+++ b/types/FileUploader/Filename.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface FilenameProps {
   /**
@@ -20,11 +21,8 @@ export interface FilenameProps {
   invalid?: boolean;
 }
 
-export default class Filename {
-  $$prop_def: FilenameProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Filename extends SvelteComponent<
+  FilenameProps,
+  { click: WindowEventMap["click"]; keydown: WindowEventMap["keydown"] },
+  {}
+> {}

--- a/types/FluidForm/FluidForm.d.ts
+++ b/types/FluidForm/FluidForm.d.ts
@@ -1,12 +1,6 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface FluidFormProps {}
 
-export default class FluidForm {
-  $$prop_def: FluidFormProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FluidForm extends SvelteComponent<FluidFormProps, {}, { default: {} }> {}

--- a/types/Form/Form.d.ts
+++ b/types/Form/Form.d.ts
@@ -1,17 +1,16 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface FormProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["form"]> {}
 
-export default class Form {
-  $$prop_def: FormProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "submit", cb: (event: WindowEventMap["submit"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Form extends SvelteComponent<
+  FormProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    submit: WindowEventMap["submit"];
+  },
+  { default: {} }
+> {}

--- a/types/FormGroup/FormGroup.d.ts
+++ b/types/FormGroup/FormGroup.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface FormGroupProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["fieldset"]> {
   /**
@@ -26,15 +27,13 @@ export interface FormGroupProps extends svelte.JSX.HTMLAttributes<HTMLElementTag
   legendText?: string;
 }
 
-export default class FormGroup {
-  $$prop_def: FormGroupProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FormGroup extends SvelteComponent<
+  FormGroupProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/FormItem/FormItem.d.ts
+++ b/types/FormItem/FormItem.d.ts
@@ -1,16 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface FormItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
 
-export default class FormItem {
-  $$prop_def: FormItemProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FormItem extends SvelteComponent<
+  FormItemProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/FormLabel/FormLabel.d.ts
+++ b/types/FormLabel/FormLabel.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface FormLabelProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {
   /**
@@ -8,15 +9,13 @@ export interface FormLabelProps extends svelte.JSX.HTMLAttributes<HTMLElementTag
   id?: string;
 }
 
-export default class FormLabel {
-  $$prop_def: FormLabelProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class FormLabel extends SvelteComponent<
+  FormLabelProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Grid/Column.d.ts
+++ b/types/Grid/Column.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type ColumnSize = boolean | number;
 
@@ -66,11 +67,8 @@ export interface ColumnProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNam
   max?: ColumnBreakpoint;
 }
 
-export default class Column {
-  $$prop_def: ColumnProps;
-  $$slot_def: {
-    default: { props: { class: string; [key: string]: any } };
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Column extends SvelteComponent<
+  ColumnProps,
+  {},
+  { default: { props: { class: string; [key: string]: any } } }
+> {}

--- a/types/Grid/Grid.d.ts
+++ b/types/Grid/Grid.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface GridProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -45,11 +46,8 @@ export interface GridProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameM
   noGutterRight?: boolean;
 }
 
-export default class Grid {
-  $$prop_def: GridProps;
-  $$slot_def: {
-    default: { props: { class: string; [key: string]: any } };
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Grid extends SvelteComponent<
+  GridProps,
+  {},
+  { default: { props: { class: string; [key: string]: any } } }
+> {}

--- a/types/Grid/Row.d.ts
+++ b/types/Grid/Row.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface RowProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -39,11 +40,8 @@ export interface RowProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMa
   noGutterRight?: boolean;
 }
 
-export default class Row {
-  $$prop_def: RowProps;
-  $$slot_def: {
-    default: { props: { class: string; [key: string]: any } };
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Row extends SvelteComponent<
+  RowProps,
+  {},
+  { default: { props: { class: string; [key: string]: any } } }
+> {}

--- a/types/Icon/Icon.d.ts
+++ b/types/Icon/Icon.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 import { IconSkeletonProps } from "./IconSkeleton";
 
 export interface IconProps extends IconSkeletonProps, svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["svg"]> {
@@ -14,13 +15,13 @@ export interface IconProps extends IconSkeletonProps, svelte.JSX.HTMLAttributes<
   skeleton?: boolean;
 }
 
-export default class Icon {
-  $$prop_def: IconProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Icon extends SvelteComponent<
+  IconProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Icon/IconSkeleton.d.ts
+++ b/types/Icon/IconSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface IconSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface IconSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElement
   size?: number;
 }
 
-export default class IconSkeleton {
-  $$prop_def: IconSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class IconSkeleton extends SvelteComponent<
+  IconSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/InlineLoading/InlineLoading.d.ts
+++ b/types/InlineLoading/InlineLoading.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface InlineLoadingProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -24,14 +25,14 @@ export interface InlineLoadingProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   successDelay?: number;
 }
 
-export default class InlineLoading {
-  $$prop_def: InlineLoadingProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "success", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class InlineLoading extends SvelteComponent<
+  InlineLoadingProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    success: CustomEvent<any>;
+  },
+  {}
+> {}

--- a/types/Link/Link.d.ts
+++ b/types/Link/Link.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface LinkProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {
   /**
@@ -36,15 +37,13 @@ export interface LinkProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameM
   ref?: null | HTMLAnchorElement | HTMLParagraphElement;
 }
 
-export default class Link {
-  $$prop_def: LinkProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Link extends SvelteComponent<
+  LinkProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/ListBox/ListBox.d.ts
+++ b/types/ListBox/ListBox.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ListBoxProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -43,13 +44,8 @@ export interface ListBoxProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNa
   invalidText?: string;
 }
 
-export default class ListBox {
-  $$prop_def: ListBoxProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ListBox extends SvelteComponent<
+  ListBoxProps,
+  { keydown: WindowEventMap["keydown"]; click: WindowEventMap["click"] },
+  { default: {} }
+> {}

--- a/types/ListBox/ListBoxField.d.ts
+++ b/types/ListBox/ListBoxField.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type ListBoxFieldTranslationId = "close" | "open";
 
@@ -47,17 +48,15 @@ export interface ListBoxFieldProps extends svelte.JSX.HTMLAttributes<HTMLElement
   ref?: null | HTMLDivElement;
 }
 
-export default class ListBoxField {
-  $$prop_def: ListBoxFieldProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ListBoxField extends SvelteComponent<
+  ListBoxFieldProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keydown: WindowEventMap["keydown"];
+    blur: WindowEventMap["blur"];
+  },
+  { default: {} }
+> {}

--- a/types/ListBox/ListBoxMenu.d.ts
+++ b/types/ListBox/ListBoxMenu.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ListBoxMenuProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -14,12 +15,8 @@ export interface ListBoxMenuProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   ref?: null | HTMLDivElement;
 }
 
-export default class ListBoxMenu {
-  $$prop_def: ListBoxMenuProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "scroll", cb: (event: WindowEventMap["scroll"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ListBoxMenu extends SvelteComponent<
+  ListBoxMenuProps,
+  { scroll: WindowEventMap["scroll"] },
+  { default: {} }
+> {}

--- a/types/ListBox/ListBoxMenuIcon.d.ts
+++ b/types/ListBox/ListBoxMenuIcon.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type ListBoxMenuIconTranslationId = "close" | "open";
 
@@ -23,10 +24,8 @@ export interface ListBoxMenuIconProps extends svelte.JSX.HTMLAttributes<HTMLElem
   translateWithId?: (id: ListBoxMenuIconTranslationId) => string;
 }
 
-export default class ListBoxMenuIcon {
-  $$prop_def: ListBoxMenuIconProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ListBoxMenuIcon extends SvelteComponent<
+  ListBoxMenuIconProps,
+  { click: WindowEventMap["click"] },
+  {}
+> {}

--- a/types/ListBox/ListBoxMenuItem.d.ts
+++ b/types/ListBox/ListBoxMenuItem.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ListBoxMenuItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -14,14 +15,12 @@ export interface ListBoxMenuItemProps extends svelte.JSX.HTMLAttributes<HTMLElem
   highlighted?: boolean;
 }
 
-export default class ListBoxMenuItem {
-  $$prop_def: ListBoxMenuItemProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ListBoxMenuItem extends SvelteComponent<
+  ListBoxMenuItemProps,
+  {
+    click: WindowEventMap["click"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/ListBox/ListBoxSelection.d.ts
+++ b/types/ListBox/ListBoxSelection.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 
@@ -34,10 +35,4 @@ export interface ListBoxSelectionProps extends svelte.JSX.HTMLAttributes<HTMLEle
   ref?: null | HTMLDivElement;
 }
 
-export default class ListBoxSelection {
-  $$prop_def: ListBoxSelectionProps;
-  $$slot_def: {};
-
-  $on(eventname: "clear", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ListBoxSelection extends SvelteComponent<ListBoxSelectionProps, { clear: CustomEvent<any> }, {}> {}

--- a/types/ListItem/ListItem.d.ts
+++ b/types/ListItem/ListItem.d.ts
@@ -1,16 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ListItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {}
 
-export default class ListItem {
-  $$prop_def: ListItemProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ListItem extends SvelteComponent<
+  ListItemProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Loading/Loading.d.ts
+++ b/types/Loading/Loading.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface LoadingProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -32,9 +33,4 @@ export interface LoadingProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNa
   id?: string;
 }
 
-export default class Loading {
-  $$prop_def: LoadingProps;
-  $$slot_def: {};
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Loading extends SvelteComponent<LoadingProps, {}, {}> {}

--- a/types/Modal/Modal.d.ts
+++ b/types/Modal/Modal.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ModalProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -112,22 +113,18 @@ export interface ModalProps extends svelte.JSX.HTMLAttributes<HTMLElementTagName
   ref?: null | HTMLDivElement;
 }
 
-export default class Modal {
-  $$prop_def: ModalProps;
-  $$slot_def: {
-    default: {};
-    heading: {};
-    label: {};
-  };
-
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "submit", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: "click:button--secondary", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: "close", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: "open", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Modal extends SvelteComponent<
+  ModalProps,
+  {
+    keydown: WindowEventMap["keydown"];
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    submit: CustomEvent<any>;
+    ["click:button--secondary"]: CustomEvent<any>;
+    close: CustomEvent<any>;
+    open: CustomEvent<any>;
+  },
+  { default: {}; heading: {}; label: {} }
+> {}

--- a/types/MultiSelect/MultiSelect.d.ts
+++ b/types/MultiSelect/MultiSelect.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type MultiSelectItemId = string;
 
@@ -154,14 +155,14 @@ export interface MultiSelectProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   name?: string;
 }
 
-export default class MultiSelect {
-  $$prop_def: MultiSelectProps;
-  $$slot_def: {};
-
-  $on(eventname: "clear", cb: (event: WindowEventMap["clear"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: "select", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class MultiSelect extends SvelteComponent<
+  MultiSelectProps,
+  {
+    clear: WindowEventMap["clear"];
+    keydown: WindowEventMap["keydown"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+    select: CustomEvent<any>;
+  },
+  {}
+> {}

--- a/types/Notification/InlineNotification.d.ts
+++ b/types/Notification/InlineNotification.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface InlineNotificationProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -56,17 +57,14 @@ export interface InlineNotificationProps extends svelte.JSX.HTMLAttributes<HTMLE
   iconDescription?: string;
 }
 
-export default class InlineNotification {
-  $$prop_def: InlineNotificationProps;
-  $$slot_def: {
-    default: {};
-    actions: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "close", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class InlineNotification extends SvelteComponent<
+  InlineNotificationProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    close: CustomEvent<any>;
+  },
+  { default: {}; actions: {} }
+> {}

--- a/types/Notification/NotificationActionButton.d.ts
+++ b/types/Notification/NotificationActionButton.d.ts
@@ -1,16 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface NotificationActionButtonProps {}
 
-export default class NotificationActionButton {
-  $$prop_def: NotificationActionButtonProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class NotificationActionButton extends SvelteComponent<
+  NotificationActionButtonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Notification/NotificationButton.d.ts
+++ b/types/Notification/NotificationButton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface NotificationButtonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -24,13 +25,13 @@ export interface NotificationButtonProps extends svelte.JSX.HTMLAttributes<HTMLE
   iconDescription?: string;
 }
 
-export default class NotificationButton {
-  $$prop_def: NotificationButtonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class NotificationButton extends SvelteComponent<
+  NotificationButtonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Notification/NotificationIcon.d.ts
+++ b/types/Notification/NotificationIcon.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface NotificationIconProps {
   /**
@@ -20,9 +21,4 @@ export interface NotificationIconProps {
   iconDescription?: string;
 }
 
-export default class NotificationIcon {
-  $$prop_def: NotificationIconProps;
-  $$slot_def: {};
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class NotificationIcon extends SvelteComponent<NotificationIconProps, {}, {}> {}

--- a/types/Notification/NotificationTextDetails.d.ts
+++ b/types/Notification/NotificationTextDetails.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface NotificationTextDetailsProps {
   /**
@@ -26,11 +27,8 @@ export interface NotificationTextDetailsProps {
   caption?: string;
 }
 
-export default class NotificationTextDetails {
-  $$prop_def: NotificationTextDetailsProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class NotificationTextDetails extends SvelteComponent<
+  NotificationTextDetailsProps,
+  {},
+  { default: {} }
+> {}

--- a/types/Notification/ToastNotification.d.ts
+++ b/types/Notification/ToastNotification.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToastNotificationProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -62,16 +63,14 @@ export interface ToastNotificationProps extends svelte.JSX.HTMLAttributes<HTMLEl
   hideCloseButton?: boolean;
 }
 
-export default class ToastNotification {
-  $$prop_def: ToastNotificationProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "close", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToastNotification extends SvelteComponent<
+  ToastNotificationProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    close: CustomEvent<any>;
+  },
+  { default: {} }
+> {}

--- a/types/NumberInput/NumberInput.d.ts
+++ b/types/NumberInput/NumberInput.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export type NumberInputTranslationId = "increment" | "decrement";
 
@@ -127,17 +128,15 @@ export interface NumberInputProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   ref?: null | HTMLInputElement;
 }
 
-export default class NumberInput {
-  $$prop_def: NumberInputProps;
-  $$slot_def: {
-    label: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
-  $on(eventname: "change", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class NumberInput extends SvelteComponent<
+  NumberInputProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    input: WindowEventMap["input"];
+    change: CustomEvent<any>;
+  },
+  { label: {} }
+> {}

--- a/types/NumberInput/NumberInputSkeleton.d.ts
+++ b/types/NumberInput/NumberInputSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface NumberInputSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface NumberInputSkeletonProps extends svelte.JSX.HTMLAttributes<HTML
   hideLabel?: boolean;
 }
 
-export default class NumberInputSkeleton {
-  $$prop_def: NumberInputSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class NumberInputSkeleton extends SvelteComponent<
+  NumberInputSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/OrderedList/OrderedList.d.ts
+++ b/types/OrderedList/OrderedList.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface OrderedListProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ol"]> {
   /**
@@ -14,15 +15,13 @@ export interface OrderedListProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   native?: boolean;
 }
 
-export default class OrderedList {
-  $$prop_def: OrderedListProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class OrderedList extends SvelteComponent<
+  OrderedListProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/OverflowMenu/OverflowMenu.d.ts
+++ b/types/OverflowMenu/OverflowMenu.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface OverflowMenuProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -70,18 +71,15 @@ export interface OverflowMenuProps extends svelte.JSX.HTMLAttributes<HTMLElement
   menuRef?: null | HTMLUListElement;
 }
 
-export default class OverflowMenu {
-  $$prop_def: OverflowMenuProps;
-  $$slot_def: {
-    default: {};
-    menu: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "close", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class OverflowMenu extends SvelteComponent<
+  OverflowMenuProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keydown: WindowEventMap["keydown"];
+    close: CustomEvent<any>;
+  },
+  { default: {}; menu: {} }
+> {}

--- a/types/OverflowMenu/OverflowMenuItem.d.ts
+++ b/types/OverflowMenu/OverflowMenuItem.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface OverflowMenuItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
   /**
@@ -57,13 +58,8 @@ export interface OverflowMenuItemProps extends svelte.JSX.HTMLAttributes<HTMLEle
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
 }
 
-export default class OverflowMenuItem {
-  $$prop_def: OverflowMenuItemProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class OverflowMenuItem extends SvelteComponent<
+  OverflowMenuItemProps,
+  { click: WindowEventMap["click"]; keydown: WindowEventMap["keydown"] },
+  { default: {} }
+> {}

--- a/types/Pagination/Pagination.d.ts
+++ b/types/Pagination/Pagination.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface PaginationProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -98,10 +99,4 @@ export interface PaginationProps extends svelte.JSX.HTMLAttributes<HTMLElementTa
   id?: string;
 }
 
-export default class Pagination {
-  $$prop_def: PaginationProps;
-  $$slot_def: {};
-
-  $on(eventname: "update", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Pagination extends SvelteComponent<PaginationProps, { update: CustomEvent<any> }, {}> {}

--- a/types/Pagination/PaginationSkeleton.d.ts
+++ b/types/Pagination/PaginationSkeleton.d.ts
@@ -1,14 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface PaginationSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
 
-export default class PaginationSkeleton {
-  $$prop_def: PaginationSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class PaginationSkeleton extends SvelteComponent<
+  PaginationSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/PaginationNav/PaginationNav.d.ts
+++ b/types/PaginationNav/PaginationNav.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface PaginationNavProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
   /**
@@ -38,12 +39,8 @@ export interface PaginationNavProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   backwardText?: string;
 }
 
-export default class PaginationNav {
-  $$prop_def: PaginationNavProps;
-  $$slot_def: {};
-
-  $on(eventname: "click:button--previous", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: "click:button--next", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: "change", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class PaginationNav extends SvelteComponent<
+  PaginationNavProps,
+  { ["click:button--previous"]: CustomEvent<any>; ["click:button--next"]: CustomEvent<any>; change: CustomEvent<any> },
+  {}
+> {}

--- a/types/ProgressIndicator/ProgressIndicator.d.ts
+++ b/types/ProgressIndicator/ProgressIndicator.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ProgressIndicatorProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {
   /**
@@ -26,16 +27,14 @@ export interface ProgressIndicatorProps extends svelte.JSX.HTMLAttributes<HTMLEl
   preventChangeOnClick?: boolean;
 }
 
-export default class ProgressIndicator {
-  $$prop_def: ProgressIndicatorProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "change", cb: (event: CustomEvent<number>) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ProgressIndicator extends SvelteComponent<
+  ProgressIndicatorProps,
+  {
+    change: CustomEvent<number>;
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/ProgressIndicator/ProgressIndicatorSkeleton.d.ts
+++ b/types/ProgressIndicator/ProgressIndicatorSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ProgressIndicatorSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {
   /**
@@ -14,13 +15,13 @@ export interface ProgressIndicatorSkeletonProps extends svelte.JSX.HTMLAttribute
   count?: number;
 }
 
-export default class ProgressIndicatorSkeleton {
-  $$prop_def: ProgressIndicatorSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ProgressIndicatorSkeleton extends SvelteComponent<
+  ProgressIndicatorSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/ProgressIndicator/ProgressStep.d.ts
+++ b/types/ProgressIndicator/ProgressStep.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ProgressStepProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
   /**
@@ -50,16 +51,14 @@ export interface ProgressStepProps extends svelte.JSX.HTMLAttributes<HTMLElement
   id?: string;
 }
 
-export default class ProgressStep {
-  $$prop_def: ProgressStepProps;
-  $$slot_def: {
-    default: { props: { class: "bx--progress-label" } };
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ProgressStep extends SvelteComponent<
+  ProgressStepProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keydown: WindowEventMap["keydown"];
+  },
+  { default: { props: { class: "bx--progress-label" } } }
+> {}

--- a/types/RadioButton/RadioButton.d.ts
+++ b/types/RadioButton/RadioButton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface RadioButtonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -56,10 +57,4 @@ export interface RadioButtonProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   ref?: null | HTMLInputElement;
 }
 
-export default class RadioButton {
-  $$prop_def: RadioButtonProps;
-  $$slot_def: {};
-
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class RadioButton extends SvelteComponent<RadioButtonProps, { change: WindowEventMap["change"] }, {}> {}

--- a/types/RadioButton/RadioButtonSkeleton.d.ts
+++ b/types/RadioButton/RadioButtonSkeleton.d.ts
@@ -1,14 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface RadioButtonSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
 
-export default class RadioButtonSkeleton {
-  $$prop_def: RadioButtonSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class RadioButtonSkeleton extends SvelteComponent<
+  RadioButtonSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/RadioButtonGroup/RadioButtonGroup.d.ts
+++ b/types/RadioButtonGroup/RadioButtonGroup.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface RadioButtonGroupProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -30,16 +31,14 @@ export interface RadioButtonGroupProps extends svelte.JSX.HTMLAttributes<HTMLEle
   id?: string;
 }
 
-export default class RadioButtonGroup {
-  $$prop_def: RadioButtonGroupProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class RadioButtonGroup extends SvelteComponent<
+  RadioButtonGroupProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: CustomEvent<any>;
+  },
+  { default: {} }
+> {}

--- a/types/Search/Search.d.ts
+++ b/types/Search/Search.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SearchProps {
   /**
@@ -85,18 +86,18 @@ export interface SearchProps {
   ref?: null | HTMLInputElement;
 }
 
-export default class Search {
-  $$prop_def: SearchProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: "clear", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Search extends SvelteComponent<
+  SearchProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+    input: WindowEventMap["input"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+    clear: CustomEvent<any>;
+  },
+  {}
+> {}

--- a/types/Search/SearchSkeleton.d.ts
+++ b/types/Search/SearchSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SearchSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -13,13 +14,13 @@ export interface SearchSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   size?: "sm" | "lg" | "xl";
 }
 
-export default class SearchSkeleton {
-  $$prop_def: SearchSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SearchSkeleton extends SvelteComponent<
+  SearchSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Select/Select.d.ts
+++ b/types/Select/Select.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SelectProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -83,13 +84,8 @@ export interface SelectProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNam
   ref?: null | HTMLSelectElement;
 }
 
-export default class Select {
-  $$prop_def: SelectProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: "change", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Select extends SvelteComponent<
+  SelectProps,
+  { blur: WindowEventMap["blur"]; change: CustomEvent<any> },
+  { default: {} }
+> {}

--- a/types/Select/SelectItem.d.ts
+++ b/types/Select/SelectItem.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SelectItemProps {
   /**
@@ -26,9 +27,4 @@ export interface SelectItemProps {
   disabled?: boolean;
 }
 
-export default class SelectItem {
-  $$prop_def: SelectItemProps;
-  $$slot_def: {};
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SelectItem extends SvelteComponent<SelectItemProps, {}, {}> {}

--- a/types/Select/SelectItemGroup.d.ts
+++ b/types/Select/SelectItemGroup.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SelectItemGroupProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["optgroup"]> {
   /**
@@ -14,11 +15,4 @@ export interface SelectItemGroupProps extends svelte.JSX.HTMLAttributes<HTMLElem
   label?: string;
 }
 
-export default class SelectItemGroup {
-  $$prop_def: SelectItemGroupProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SelectItemGroup extends SvelteComponent<SelectItemGroupProps, {}, { default: {} }> {}

--- a/types/Select/SelectSkeleton.d.ts
+++ b/types/Select/SelectSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SelectSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface SelectSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   hideLabel?: boolean;
 }
 
-export default class SelectSkeleton {
-  $$prop_def: SelectSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SelectSkeleton extends SvelteComponent<
+  SelectSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/SkeletonPlaceholder/SkeletonPlaceholder.d.ts
+++ b/types/SkeletonPlaceholder/SkeletonPlaceholder.d.ts
@@ -1,14 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SkeletonPlaceholderProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
 
-export default class SkeletonPlaceholder {
-  $$prop_def: SkeletonPlaceholderProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SkeletonPlaceholder extends SvelteComponent<
+  SkeletonPlaceholderProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/SkeletonText/SkeletonText.d.ts
+++ b/types/SkeletonText/SkeletonText.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SkeletonTextProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -26,13 +27,13 @@ export interface SkeletonTextProps extends svelte.JSX.HTMLAttributes<HTMLElement
   width?: string;
 }
 
-export default class SkeletonText {
-  $$prop_def: SkeletonTextProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SkeletonText extends SvelteComponent<
+  SkeletonTextProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Slider/Slider.d.ts
+++ b/types/Slider/Slider.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SliderProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -104,14 +105,14 @@ export interface SliderProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNam
   ref?: null | HTMLDivElement;
 }
 
-export default class Slider {
-  $$prop_def: SliderProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Slider extends SvelteComponent<
+  SliderProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: CustomEvent<any>;
+  },
+  {}
+> {}

--- a/types/Slider/SliderSkeleton.d.ts
+++ b/types/Slider/SliderSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SliderSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface SliderSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   hideLabel?: boolean;
 }
 
-export default class SliderSkeleton {
-  $$prop_def: SliderSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SliderSkeleton extends SvelteComponent<
+  SliderSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/StructuredList/StructuredList.d.ts
+++ b/types/StructuredList/StructuredList.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface StructuredListProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -19,16 +20,14 @@ export interface StructuredListProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   selection?: boolean;
 }
 
-export default class StructuredList {
-  $$prop_def: StructuredListProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class StructuredList extends SvelteComponent<
+  StructuredListProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: CustomEvent<any>;
+  },
+  { default: {} }
+> {}

--- a/types/StructuredList/StructuredListBody.d.ts
+++ b/types/StructuredList/StructuredListBody.d.ts
@@ -1,16 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface StructuredListBodyProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
 
-export default class StructuredListBody {
-  $$prop_def: StructuredListBodyProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class StructuredListBody extends SvelteComponent<
+  StructuredListBodyProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/StructuredList/StructuredListCell.d.ts
+++ b/types/StructuredList/StructuredListCell.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface StructuredListCellProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -14,15 +15,13 @@ export interface StructuredListCellProps extends svelte.JSX.HTMLAttributes<HTMLE
   noWrap?: boolean;
 }
 
-export default class StructuredListCell {
-  $$prop_def: StructuredListCellProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class StructuredListCell extends SvelteComponent<
+  StructuredListCellProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/StructuredList/StructuredListHead.d.ts
+++ b/types/StructuredList/StructuredListHead.d.ts
@@ -1,16 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface StructuredListHeadProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
 
-export default class StructuredListHead {
-  $$prop_def: StructuredListHeadProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class StructuredListHead extends SvelteComponent<
+  StructuredListHeadProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/StructuredList/StructuredListInput.d.ts
+++ b/types/StructuredList/StructuredListInput.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface StructuredListInputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
   /**
@@ -38,9 +39,4 @@ export interface StructuredListInputProps extends svelte.JSX.HTMLAttributes<HTML
   ref?: null | HTMLInputElement;
 }
 
-export default class StructuredListInput {
-  $$prop_def: StructuredListInputProps;
-  $$slot_def: {};
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class StructuredListInput extends SvelteComponent<StructuredListInputProps, {}, {}> {}

--- a/types/StructuredList/StructuredListRow.d.ts
+++ b/types/StructuredList/StructuredListRow.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface StructuredListRowProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {
   /**
@@ -20,16 +21,14 @@ export interface StructuredListRowProps extends svelte.JSX.HTMLAttributes<HTMLEl
   tabindex?: string;
 }
 
-export default class StructuredListRow {
-  $$prop_def: StructuredListRowProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class StructuredListRow extends SvelteComponent<
+  StructuredListRowProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keydown: WindowEventMap["keydown"];
+  },
+  { default: {} }
+> {}

--- a/types/StructuredList/StructuredListSkeleton.d.ts
+++ b/types/StructuredList/StructuredListSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface StructuredListSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -14,13 +15,13 @@ export interface StructuredListSkeletonProps extends svelte.JSX.HTMLAttributes<H
   border?: boolean;
 }
 
-export default class StructuredListSkeleton {
-  $$prop_def: StructuredListSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class StructuredListSkeleton extends SvelteComponent<
+  StructuredListSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Tabs/Tab.d.ts
+++ b/types/Tabs/Tab.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TabProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
   /**
@@ -39,14 +40,12 @@ export interface TabProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMa
   ref?: null | HTMLAnchorElement;
 }
 
-export default class Tab {
-  $$prop_def: TabProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Tab extends SvelteComponent<
+  TabProps,
+  {
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Tabs/TabContent.d.ts
+++ b/types/Tabs/TabContent.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TabContentProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,11 +9,4 @@ export interface TabContentProps extends svelte.JSX.HTMLAttributes<HTMLElementTa
   id?: string;
 }
 
-export default class TabContent {
-  $$prop_def: TabContentProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TabContent extends SvelteComponent<TabContentProps, {}, { default: {} }> {}

--- a/types/Tabs/Tabs.d.ts
+++ b/types/Tabs/Tabs.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TabsProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -26,15 +27,8 @@ export interface TabsProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameM
   triggerHref?: string;
 }
 
-export default class Tabs {
-  $$prop_def: TabsProps;
-  $$slot_def: {
-    default: {};
-    content: {};
-  };
-
-  $on(eventname: "keypress", cb: (event: WindowEventMap["keypress"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "change", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Tabs extends SvelteComponent<
+  TabsProps,
+  { keypress: WindowEventMap["keypress"]; click: WindowEventMap["click"]; change: CustomEvent<any> },
+  { default: {}; content: {} }
+> {}

--- a/types/Tabs/TabsSkeleton.d.ts
+++ b/types/Tabs/TabsSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TabsSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface TabsSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElement
   count?: number;
 }
 
-export default class TabsSkeleton {
-  $$prop_def: TabsSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TabsSkeleton extends SvelteComponent<
+  TabsSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Tag/Tag.d.ts
+++ b/types/Tag/Tag.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TagProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]>,
@@ -50,15 +51,13 @@ export interface TagProps
   id?: string;
 }
 
-export default class Tag {
-  $$prop_def: TagProps;
-  $$slot_def: {
-    default: { props: { class: "bx--tag__label" } };
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Tag extends SvelteComponent<
+  TagProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: { props: { class: "bx--tag__label" } } }
+> {}

--- a/types/Tag/TagSkeleton.d.ts
+++ b/types/Tag/TagSkeleton.d.ts
@@ -1,14 +1,15 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TagSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {}
 
-export default class TagSkeleton {
-  $$prop_def: TagSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TagSkeleton extends SvelteComponent<
+  TagSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/TextArea/TextArea.d.ts
+++ b/types/TextArea/TextArea.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TextAreaProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["textarea"]> {
   /**
@@ -85,17 +86,17 @@ export interface TextAreaProps extends svelte.JSX.HTMLAttributes<HTMLElementTagN
   ref?: null | HTMLTextAreaElement;
 }
 
-export default class TextArea {
-  $$prop_def: TextAreaProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TextArea extends SvelteComponent<
+  TextAreaProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+    input: WindowEventMap["input"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
+> {}

--- a/types/TextArea/TextAreaSkeleton.d.ts
+++ b/types/TextArea/TextAreaSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TextAreaSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface TextAreaSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEle
   hideLabel?: boolean;
 }
 
-export default class TextAreaSkeleton {
-  $$prop_def: TextAreaSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TextAreaSkeleton extends SvelteComponent<
+  TextAreaSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/TextInput/PasswordInput.d.ts
+++ b/types/TextInput/PasswordInput.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface PasswordInputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -106,18 +107,18 @@ export interface PasswordInputProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   ref?: null | HTMLInputElement;
 }
 
-export default class PasswordInput {
-  $$prop_def: PasswordInputProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class PasswordInput extends SvelteComponent<
+  PasswordInputProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+    input: WindowEventMap["input"];
+    keydown: WindowEventMap["keydown"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
+> {}

--- a/types/TextInput/TextInput.d.ts
+++ b/types/TextInput/TextInput.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TextInputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -108,18 +109,18 @@ export interface TextInputProps extends svelte.JSX.HTMLAttributes<HTMLElementTag
   inline?: boolean;
 }
 
-export default class TextInput {
-  $$prop_def: TextInputProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TextInput extends SvelteComponent<
+  TextInputProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+    input: WindowEventMap["input"];
+    keydown: WindowEventMap["keydown"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
+> {}

--- a/types/TextInput/TextInputSkeleton.d.ts
+++ b/types/TextInput/TextInputSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TextInputSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,13 +9,13 @@ export interface TextInputSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEl
   hideLabel?: boolean;
 }
 
-export default class TextInputSkeleton {
-  $$prop_def: TextInputSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TextInputSkeleton extends SvelteComponent<
+  TextInputSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Tile/ClickableTile.d.ts
+++ b/types/Tile/ClickableTile.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ClickableTileProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -19,16 +20,14 @@ export interface ClickableTileProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   href?: string;
 }
 
-export default class ClickableTile {
-  $$prop_def: ClickableTileProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ClickableTile extends SvelteComponent<
+  ClickableTileProps,
+  {
+    click: WindowEventMap["click"];
+    keydown: WindowEventMap["keydown"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Tile/ExpandableTile.d.ts
+++ b/types/Tile/ExpandableTile.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ExpandableTileProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -56,17 +57,14 @@ export interface ExpandableTileProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   ref?: null | HTMLDivElement;
 }
 
-export default class ExpandableTile {
-  $$prop_def: ExpandableTileProps;
-  $$slot_def: {
-    above: {};
-    below: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "keypress", cb: (event: WindowEventMap["keypress"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ExpandableTile extends SvelteComponent<
+  ExpandableTileProps,
+  {
+    click: WindowEventMap["click"];
+    keypress: WindowEventMap["keypress"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { above: {}; below: {} }
+> {}

--- a/types/Tile/RadioTile.d.ts
+++ b/types/Tile/RadioTile.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface RadioTileProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {
   /**
@@ -44,17 +45,15 @@ export interface RadioTileProps extends svelte.JSX.HTMLAttributes<HTMLElementTag
   name?: string;
 }
 
-export default class RadioTile {
-  $$prop_def: RadioTileProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class RadioTile extends SvelteComponent<
+  RadioTileProps,
+  {
+    change: WindowEventMap["change"];
+    keydown: WindowEventMap["keydown"];
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Tile/SelectableTile.d.ts
+++ b/types/Tile/SelectableTile.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SelectableTileProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {
   /**
@@ -56,16 +57,14 @@ export interface SelectableTileProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   ref?: null | HTMLInputElement;
 }
 
-export default class SelectableTile {
-  $$prop_def: SelectableTileProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SelectableTile extends SvelteComponent<
+  SelectableTileProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keydown: WindowEventMap["keydown"];
+  },
+  { default: {} }
+> {}

--- a/types/Tile/Tile.d.ts
+++ b/types/Tile/Tile.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TileProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -8,15 +9,13 @@ export interface TileProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameM
   light?: boolean;
 }
 
-export default class Tile {
-  $$prop_def: TileProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Tile extends SvelteComponent<
+  TileProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Tile/TileGroup.d.ts
+++ b/types/Tile/TileGroup.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TileGroupProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["fieldset"]> {
   /**
@@ -19,12 +20,4 @@ export interface TileGroupProps extends svelte.JSX.HTMLAttributes<HTMLElementTag
   legend?: string;
 }
 
-export default class TileGroup {
-  $$prop_def: TileGroupProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "select", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TileGroup extends SvelteComponent<TileGroupProps, { select: CustomEvent<any> }, { default: {} }> {}

--- a/types/TimePicker/TimePicker.d.ts
+++ b/types/TimePicker/TimePicker.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TimePickerProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -90,19 +91,17 @@ export interface TimePickerProps extends svelte.JSX.HTMLAttributes<HTMLElementTa
   ref?: null | HTMLInputElement;
 }
 
-export default class TimePicker {
-  $$prop_def: TimePickerProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TimePicker extends SvelteComponent<
+  TimePickerProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+    input: WindowEventMap["input"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  { default: {} }
+> {}

--- a/types/TimePicker/TimePickerSelect.d.ts
+++ b/types/TimePicker/TimePickerSelect.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TimePickerSelectProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -48,15 +49,13 @@ export interface TimePickerSelectProps extends svelte.JSX.HTMLAttributes<HTMLEle
   ref?: null | HTMLSelectElement;
 }
 
-export default class TimePickerSelect {
-  $$prop_def: TimePickerSelectProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TimePickerSelect extends SvelteComponent<
+  TimePickerSelectProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/types/Toggle/Toggle.d.ts
+++ b/types/Toggle/Toggle.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToggleProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -49,17 +50,17 @@ export interface ToggleProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNam
   name?: string;
 }
 
-export default class Toggle {
-  $$prop_def: ToggleProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "keyup", cb: (event: WindowEventMap["keyup"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Toggle extends SvelteComponent<
+  ToggleProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+    keyup: WindowEventMap["keyup"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
+> {}

--- a/types/Toggle/ToggleSkeleton.d.ts
+++ b/types/Toggle/ToggleSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToggleSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -20,13 +21,13 @@ export interface ToggleSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLEleme
   id?: string;
 }
 
-export default class ToggleSkeleton {
-  $$prop_def: ToggleSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToggleSkeleton extends SvelteComponent<
+  ToggleSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/ToggleSmall/ToggleSmall.d.ts
+++ b/types/ToggleSmall/ToggleSmall.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToggleSmallProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -43,17 +44,17 @@ export interface ToggleSmallProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   name?: string;
 }
 
-export default class ToggleSmall {
-  $$prop_def: ToggleSmallProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
-  $on(eventname: "keyup", cb: (event: WindowEventMap["keyup"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToggleSmall extends SvelteComponent<
+  ToggleSmallProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    change: WindowEventMap["change"];
+    keyup: WindowEventMap["keyup"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
+> {}

--- a/types/ToggleSmall/ToggleSmallSkeleton.d.ts
+++ b/types/ToggleSmall/ToggleSmallSkeleton.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ToggleSmallSkeletonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -14,13 +15,13 @@ export interface ToggleSmallSkeletonProps extends svelte.JSX.HTMLAttributes<HTML
   id?: string;
 }
 
-export default class ToggleSmallSkeleton {
-  $$prop_def: ToggleSmallSkeletonProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class ToggleSmallSkeleton extends SvelteComponent<
+  ToggleSmallSkeletonProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  {}
+> {}

--- a/types/Tooltip/Tooltip.d.ts
+++ b/types/Tooltip/Tooltip.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TooltipProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -80,13 +81,4 @@ export interface TooltipProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNa
   refIcon?: null | HTMLDivElement;
 }
 
-export default class Tooltip {
-  $$prop_def: TooltipProps;
-  $$slot_def: {
-    default: {};
-    icon: {};
-    triggerText: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Tooltip extends SvelteComponent<TooltipProps, {}, { default: {}; icon: {}; triggerText: {} }> {}

--- a/types/TooltipDefinition/TooltipDefinition.d.ts
+++ b/types/TooltipDefinition/TooltipDefinition.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TooltipDefinitionProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
@@ -32,17 +33,14 @@ export interface TooltipDefinitionProps extends svelte.JSX.HTMLAttributes<HTMLEl
   ref?: null | HTMLButtonElement;
 }
 
-export default class TooltipDefinition {
-  $$prop_def: TooltipDefinitionProps;
-  $$slot_def: {
-    default: {};
-    tooltip: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TooltipDefinition extends SvelteComponent<
+  TooltipDefinitionProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    focus: WindowEventMap["focus"];
+  },
+  { default: {}; tooltip: {} }
+> {}

--- a/types/TooltipIcon/TooltipIcon.d.ts
+++ b/types/TooltipIcon/TooltipIcon.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface TooltipIconProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -32,16 +33,14 @@ export interface TooltipIconProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   ref?: null | HTMLButtonElement;
 }
 
-export default class TooltipIcon {
-  $$prop_def: TooltipIconProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class TooltipIcon extends SvelteComponent<
+  TooltipIconProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    focus: WindowEventMap["focus"];
+  },
+  { default: {} }
+> {}

--- a/types/UIShell/Content.d.ts
+++ b/types/UIShell/Content.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface ContentProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["main"]> {
   /**
@@ -8,11 +9,4 @@ export interface ContentProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNa
   id?: string;
 }
 
-export default class Content {
-  $$prop_def: ContentProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Content extends SvelteComponent<ContentProps, {}, { default: {} }> {}

--- a/types/UIShell/GlobalHeader/Header.d.ts
+++ b/types/UIShell/GlobalHeader/Header.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -48,14 +49,8 @@ export interface HeaderProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNam
   ref?: null | HTMLAnchorElement;
 }
 
-export default class Header {
-  $$prop_def: HeaderProps;
-  $$slot_def: {
-    default: {};
-    platform: {};
-    ["skip-to-content"]: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class Header extends SvelteComponent<
+  HeaderProps,
+  { click: WindowEventMap["click"] },
+  { default: {}; platform: {}; ["skip-to-content"]: {} }
+> {}

--- a/types/UIShell/GlobalHeader/HeaderAction.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderAction.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderActionProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -25,14 +26,8 @@ export interface HeaderActionProps extends svelte.JSX.HTMLAttributes<HTMLElement
   ref?: null | HTMLButtonElement;
 }
 
-export default class HeaderAction {
-  $$prop_def: HeaderActionProps;
-  $$slot_def: {
-    default: {};
-    text: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "close", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderAction extends SvelteComponent<
+  HeaderActionProps,
+  { click: WindowEventMap["click"]; close: CustomEvent<any> },
+  { default: {}; text: {} }
+> {}

--- a/types/UIShell/GlobalHeader/HeaderActionLink.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderActionLink.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderActionLinkProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -24,9 +25,4 @@ export interface HeaderActionLinkProps extends svelte.JSX.HTMLAttributes<HTMLEle
   ref?: null | HTMLAnchorElement;
 }
 
-export default class HeaderActionLink {
-  $$prop_def: HeaderActionLinkProps;
-  $$slot_def: {};
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderActionLink extends SvelteComponent<HeaderActionLinkProps, {}, {}> {}

--- a/types/UIShell/GlobalHeader/HeaderActionSearch.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderActionSearch.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderActionSearchProps {
   /**
@@ -8,12 +9,12 @@ export interface HeaderActionSearchProps {
   searchIsActive?: boolean;
 }
 
-export default class HeaderActionSearch {
-  $$prop_def: HeaderActionSearchProps;
-  $$slot_def: {};
-
-  $on(eventname: "inputSearch", cb: (event: CustomEvent<{ action: "search"; textInput: string }>) => void): () => void;
-  $on(eventname: "focusInputSearch", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: "focusOutInputSearch", cb: (event: CustomEvent<any>) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderActionSearch extends SvelteComponent<
+  HeaderActionSearchProps,
+  {
+    inputSearch: CustomEvent<{ action: "search"; textInput: string }>;
+    focusInputSearch: CustomEvent<any>;
+    focusOutInputSearch: CustomEvent<any>;
+  },
+  {}
+> {}

--- a/types/UIShell/GlobalHeader/HeaderNav.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderNav.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderNavProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
   /**
@@ -7,11 +8,4 @@ export interface HeaderNavProps extends svelte.JSX.HTMLAttributes<HTMLElementTag
   ariaLabel?: string;
 }
 
-export default class HeaderNav {
-  $$prop_def: HeaderNavProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderNav extends SvelteComponent<HeaderNavProps, {}, { default: {} }> {}

--- a/types/UIShell/GlobalHeader/HeaderNavItem.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderNavItem.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderNavItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -18,17 +19,17 @@ export interface HeaderNavItemProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   ref?: null | HTMLAnchorElement;
 }
 
-export default class HeaderNavItem {
-  $$prop_def: HeaderNavItemProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keyup", cb: (event: WindowEventMap["keyup"]) => void): () => void;
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderNavItem extends SvelteComponent<
+  HeaderNavItemProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keyup: WindowEventMap["keyup"];
+    keydown: WindowEventMap["keydown"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  {}
+> {}

--- a/types/UIShell/GlobalHeader/HeaderNavMenu.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderNavMenu.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderNavMenuProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -31,19 +32,17 @@ export interface HeaderNavMenuProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   iconDescription?: string;
 }
 
-export default class HeaderNavMenu {
-  $$prop_def: HeaderNavMenuProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: "keyup", cb: (event: WindowEventMap["keyup"]) => void): () => void;
-  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
-  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderNavMenu extends SvelteComponent<
+  HeaderNavMenuProps,
+  {
+    keydown: WindowEventMap["keydown"];
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+    keyup: WindowEventMap["keyup"];
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+  },
+  { default: {} }
+> {}

--- a/types/UIShell/GlobalHeader/HeaderPanelDivider.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderPanelDivider.d.ts
@@ -1,12 +1,6 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderPanelDividerProps {}
 
-export default class HeaderPanelDivider {
-  $$prop_def: HeaderPanelDividerProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderPanelDivider extends SvelteComponent<HeaderPanelDividerProps, {}, { default: {} }> {}

--- a/types/UIShell/GlobalHeader/HeaderPanelLink.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderPanelLink.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderPanelLinkProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -13,12 +14,8 @@ export interface HeaderPanelLinkProps extends svelte.JSX.HTMLAttributes<HTMLElem
   ref?: null | HTMLAnchorElement;
 }
 
-export default class HeaderPanelLink {
-  $$prop_def: HeaderPanelLinkProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderPanelLink extends SvelteComponent<
+  HeaderPanelLinkProps,
+  { click: WindowEventMap["click"] },
+  { default: {} }
+> {}

--- a/types/UIShell/GlobalHeader/HeaderPanelLinks.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderPanelLinks.d.ts
@@ -1,12 +1,6 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderPanelLinksProps {}
 
-export default class HeaderPanelLinks {
-  $$prop_def: HeaderPanelLinksProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderPanelLinks extends SvelteComponent<HeaderPanelLinksProps, {}, { default: {} }> {}

--- a/types/UIShell/GlobalHeader/HeaderUtilities.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderUtilities.d.ts
@@ -1,12 +1,6 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderUtilitiesProps {}
 
-export default class HeaderUtilities {
-  $$prop_def: HeaderUtilitiesProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderUtilities extends SvelteComponent<HeaderUtilitiesProps, {}, { default: {} }> {}

--- a/types/UIShell/HeaderGlobalAction.d.ts
+++ b/types/UIShell/HeaderGlobalAction.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface HeaderGlobalActionProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -19,12 +20,8 @@ export interface HeaderGlobalActionProps extends svelte.JSX.HTMLAttributes<HTMLE
   ref?: null | HTMLButtonElement;
 }
 
-export default class HeaderGlobalAction {
-  $$prop_def: HeaderGlobalActionProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class HeaderGlobalAction extends SvelteComponent<
+  HeaderGlobalActionProps,
+  { click: WindowEventMap["click"] },
+  { default: {} }
+> {}

--- a/types/UIShell/SideNav/SideNav.d.ts
+++ b/types/UIShell/SideNav/SideNav.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SideNavProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
   /**
@@ -19,11 +20,4 @@ export interface SideNavProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNa
   isOpen?: boolean;
 }
 
-export default class SideNav {
-  $$prop_def: SideNavProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SideNav extends SvelteComponent<SideNavProps, {}, { default: {} }> {}

--- a/types/UIShell/SideNav/SideNavItems.d.ts
+++ b/types/UIShell/SideNav/SideNavItems.d.ts
@@ -1,12 +1,6 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SideNavItemsProps {}
 
-export default class SideNavItems {
-  $$prop_def: SideNavItemsProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SideNavItems extends SvelteComponent<SideNavItemsProps, {}, { default: {} }> {}

--- a/types/UIShell/SideNav/SideNavLink.d.ts
+++ b/types/UIShell/SideNav/SideNavLink.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SideNavLinkProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -29,10 +30,4 @@ export interface SideNavLinkProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   ref?: null | HTMLAnchorElement;
 }
 
-export default class SideNavLink {
-  $$prop_def: SideNavLinkProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SideNavLink extends SvelteComponent<SideNavLinkProps, { click: WindowEventMap["click"] }, {}> {}

--- a/types/UIShell/SideNav/SideNavMenu.d.ts
+++ b/types/UIShell/SideNav/SideNavMenu.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SideNavMenuProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -24,12 +25,8 @@ export interface SideNavMenuProps extends svelte.JSX.HTMLAttributes<HTMLElementT
   ref?: null | HTMLButtonElement;
 }
 
-export default class SideNavMenu {
-  $$prop_def: SideNavMenuProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SideNavMenu extends SvelteComponent<
+  SideNavMenuProps,
+  { click: WindowEventMap["click"] },
+  { default: {} }
+> {}

--- a/types/UIShell/SideNav/SideNavMenuItem.d.ts
+++ b/types/UIShell/SideNav/SideNavMenuItem.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SideNavMenuItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -23,10 +24,8 @@ export interface SideNavMenuItemProps extends svelte.JSX.HTMLAttributes<HTMLElem
   ref?: null | HTMLAnchorElement;
 }
 
-export default class SideNavMenuItem {
-  $$prop_def: SideNavMenuItemProps;
-  $$slot_def: {};
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SideNavMenuItem extends SvelteComponent<
+  SideNavMenuItemProps,
+  { click: WindowEventMap["click"] },
+  {}
+> {}

--- a/types/UIShell/SkipToContent.d.ts
+++ b/types/UIShell/SkipToContent.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface SkipToContentProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
@@ -14,12 +15,8 @@ export interface SkipToContentProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   tabindex?: string;
 }
 
-export default class SkipToContent {
-  $$prop_def: SkipToContentProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class SkipToContent extends SvelteComponent<
+  SkipToContentProps,
+  { click: WindowEventMap["click"] },
+  { default: {} }
+> {}

--- a/types/UnorderedList/UnorderedList.d.ts
+++ b/types/UnorderedList/UnorderedList.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="svelte" />
+import { SvelteComponent } from "svelte";
 
 export interface UnorderedListProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {
   /**
@@ -8,15 +9,13 @@ export interface UnorderedListProps extends svelte.JSX.HTMLAttributes<HTMLElemen
   nested?: boolean;
 }
 
-export default class UnorderedList {
-  $$prop_def: UnorderedListProps;
-  $$slot_def: {
-    default: {};
-  };
-
-  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
-  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
-  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
-  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
-  $on(eventname: string, cb: (event: Event) => void): () => void;
-}
+export default class UnorderedList extends SvelteComponent<
+  UnorderedListProps,
+  {
+    click: WindowEventMap["click"];
+    mouseover: WindowEventMap["mouseover"];
+    mouseenter: WindowEventMap["mouseenter"];
+    mouseleave: WindowEventMap["mouseleave"];
+  },
+  { default: {} }
+> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2728,10 +2728,10 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-sveld@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/sveld/-/sveld-0.3.0.tgz#a1a8c188511a8d5674c72fd8b2987278fae0d062"
-  integrity sha512-aEuxRaeN11P+k0DvQ+32lEzRQNzv+dFO5qRC4wSM0p5MW9i6sxgPmnYV3xy5TSzaYXVmSI9JJRSMDd3C1ayw0w==
+sveld@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/sveld/-/sveld-0.4.2.tgz#22154053c053a7d419fec89204c620cd866b64a3"
+  integrity sha512-PJvrkbJ1f1/QbJ8obnIu+UYinXZ5fIeHnGxJjqBvnlAGteIbZcG5Uexe8ymOiw5c20uA2U8YW0okyTNahrKr2g==
   dependencies:
     "@rollup/plugin-node-resolve" "^10.0.0"
     comment-parser "^0.7.6"
@@ -2741,10 +2741,10 @@ sveld@^0.3.0:
     rollup-plugin-svelte "^6.1.1"
     svelte "^3.30.0"
 
-svelte-check@^1.1.15:
-  version "1.1.15"
-  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-1.1.15.tgz#b645f4d63d7a20587f7b9755a44eb247335b669f"
-  integrity sha512-3TO5xZiH/bJtlEmQoh2zwUNIF0Fy153kXB3Q/KTjVdeqmM7Ws73rMY7tiOeTub777fv83yip0PaJpgGORyL5ZA==
+svelte-check@^1.1.17:
+  version "1.1.17"
+  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-1.1.17.tgz#8faec43882bf9b1bf98105df33a13347bd49b70d"
+  integrity sha512-5JDQyKQWtxfA0lzPKrv2F3n7zBoij0mpVaW6nrU+Zc4GsjjPepMRTDyJVGiD+hyUqebnx7RShIBnwJB6neLuOQ==
   dependencies:
     chalk "^4.0.0"
     chokidar "^3.4.1"
@@ -2777,11 +2777,6 @@ svelte-preprocess@^4.0.0:
     "@types/sass" "^1.16.0"
     detect-indent "^6.0.0"
     strip-indent "^3.0.0"
-
-svelte@^3.29.7:
-  version "3.29.7"
-  resolved "https://registry.npmjs.org/svelte/-/svelte-3.29.7.tgz#e254eb2d0d609ce0fd60f052d444ac4a66d90f7d"
-  integrity sha512-rx0g311kBODvEWUU01DFBUl3MJuJven04bvTVFUG/w0On/wuj0PajQY/QlXcJndFxG+W1s8iXKaB418tdHWc3A==
 
 svelte@^3.30.0:
   version "3.30.0"


### PR DESCRIPTION
Currently, component TypeScript definitions in this library mock the internal Svelte component API so that it is readable by the Svelte Language Server. This practice is discouraged because properties like `$$prop_def` and `$$slot_def` are intended to be private.

Released in [version 3.30](https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md#3300), Svelte supports components definitions that use the typed SvelteComponent interface. Refer to the [accepted RFC](https://github.com/sveltejs/rfcs/pull/37) for more info.

The new SvelteComponent interface provides a nice API to type props, events, and slots through generic parameters.

**Before (discouraged)**

```ts
/// <reference types="svelte" />
import { AccordionSkeletonProps } from "./AccordionSkeleton";

export interface AccordionProps extends AccordionSkeletonProps {
  /**
   * Specify alignment of accordion item chevron icon
   * @default "end"
   */
  align?: "start" | "end";

  /**
   * Specify the size of the accordion
   */
  size?: "sm" | "xl";

  /**
   * Set to `true` to disable the accordion
   * @default false
   */
  disabled?: boolean;

  /**
   * Set to `true` to display the skeleton state
   * @default false
   */
  skeleton?: boolean;
}

export default class Accordion {
  $$prop_def: AccordionProps;
  $$slot_def: {
    default: {};
  };

  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
  $on(eventname: string, cb: (event: Event) => void): () => void;
}
```

**After**

```ts
/// <reference types="svelte" />
import { SvelteComponent } from "svelte";
import { AccordionSkeletonProps } from "./AccordionSkeleton";

export interface AccordionProps extends AccordionSkeletonProps {
  /**
   * Specify alignment of accordion item chevron icon
   * @default "end"
   */
  align?: "start" | "end";

  /**
   * Specify the size of the accordion
   */
  size?: "sm" | "xl";

  /**
   * Set to `true` to disable the accordion
   * @default false
   */
  disabled?: boolean;

  /**
   * Set to `true` to display the skeleton state
   * @default false
   */
  skeleton?: boolean;
}

export default class Accordion extends SvelteComponent<
  AccordionProps,
  {
    click: WindowEventMap["click"];
    mouseover: WindowEventMap["mouseover"];
    mouseenter: WindowEventMap["mouseenter"];
    mouseleave: WindowEventMap["mouseleave"];
  },
  { default: {} }
> {}
```

---

**Breaking Changes**

Although there are no API changes, TypeScript users will need Svelte version 3.30 or greater.