### PR TITLE
Refactor UI Shell global search component

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1626,7 +1626,7 @@ export interface HeaderSearchResult {
 
 | Prop name           | Kind             | Reactive | Type                                      | Default value      | Description                                        |
 | :------------------ | :--------------- | :------- | :---------------------------------------- | ------------------ | -------------------------------------------------- |
-| selectedResultIndex | <code>let</code> | Yes      | <code>number</code>                       | <code>-1</code>    | Specify the selected result index                  |
+| selectedResultIndex | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>     | Specify the selected result index                  |
 | ref                 | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element       |
 | active              | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to activate and focus the search bar |
 | value               | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>    | Specify the search input value                     |
@@ -1634,14 +1634,16 @@ export interface HeaderSearchResult {
 
 ### Slots
 
-| Slot name | Default | Props                         | Fallback                                                                                                      |
-| :-------- | :------ | :---------------------------- | :------------------------------------------------------------------------------------------------------------ |
-| --        | Yes     | <code>{ result: any } </code> | <code>{result.text}<br /> {#if result.description}&lt;span&gt;– {result.description}&lt;/span&gt;{/if}</code> |
+| Slot name | Default | Props                                                       | Fallback                                                                                                      |
+| :-------- | :------ | :---------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| --        | Yes     | <code>{ result: HeaderSearchResult; index: number } </code> | <code>{result.text}<br /> {#if result.description}&lt;span&gt;– {result.description}&lt;/span&gt;{/if}</code> |
 
 ### Events
 
 | Event name | Type       | Detail                                                                                          |
 | :--------- | :--------- | :---------------------------------------------------------------------------------------------- |
+| active     | dispatched | <code>any</code>                                                                                |
+| inactive   | dispatched | <code>any</code>                                                                                |
 | clear      | dispatched | <code>any</code>                                                                                |
 | select     | dispatched | <code>{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }</code> |
 | change     | forwarded  | --                                                                                              |

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1,6 +1,6 @@
 # Component Index
 
-> 154 components exported from carbon-components-svelte@0.23.2.
+> 155 components exported from carbon-components-svelte@0.23.2.
 
 ## Components
 
@@ -57,6 +57,7 @@
 - [`HeaderPanelDivider`](#headerpaneldivider)
 - [`HeaderPanelLink`](#headerpanellink)
 - [`HeaderPanelLinks`](#headerpanellinks)
+- [`HeaderSearch`](#headersearch)
 - [`HeaderUtilities`](#headerutilities)
 - [`Icon`](#icon)
 - [`IconSkeleton`](#iconskeleton)
@@ -1608,6 +1609,47 @@ None.
 ### Events
 
 None.
+
+## `HeaderSearch`
+
+### Types
+
+```ts
+export interface HeaderSearchResult {
+  href: string;
+  text: string;
+  description?: string;
+}
+```
+
+### Props
+
+| Prop name           | Kind             | Reactive | Type                                      | Default value      | Description                                        |
+| :------------------ | :--------------- | :------- | :---------------------------------------- | ------------------ | -------------------------------------------------- |
+| selectedResultIndex | <code>let</code> | Yes      | <code>number</code>                       | <code>-1</code>    | Specify the selected result index                  |
+| ref                 | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element       |
+| active              | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to activate and focus the search bar |
+| value               | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>    | Specify the search input value                     |
+| results             | <code>let</code> | No       | <code>HeaderSearchResult[]</code>         | <code>[]</code>    | Render a list of search results                    |
+
+### Slots
+
+| Slot name | Default | Props                         | Fallback                                                                                                      |
+| :-------- | :------ | :---------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| --        | Yes     | <code>{ result: any } </code> | <code>{result.text}<br /> {#if result.description}&lt;span&gt;– {result.description}&lt;/span&gt;{/if}</code> |
+
+### Events
+
+| Event name | Type       | Detail                                                                                          |
+| :--------- | :--------- | :---------------------------------------------------------------------------------------------- |
+| clear      | dispatched | <code>any</code>                                                                                |
+| search     | dispatched | <code>{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }</code> |
+| change     | forwarded  | --                                                                                              |
+| input      | forwarded  | --                                                                                              |
+| focus      | forwarded  | --                                                                                              |
+| blur       | forwarded  | --                                                                                              |
+| keydown    | forwarded  | --                                                                                              |
+| select     | dispatched | --                                                                                              |
 
 ## `HeaderUtilities`
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1643,13 +1643,12 @@ export interface HeaderSearchResult {
 | Event name | Type       | Detail                                                                                          |
 | :--------- | :--------- | :---------------------------------------------------------------------------------------------- |
 | clear      | dispatched | <code>any</code>                                                                                |
-| search     | dispatched | <code>{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }</code> |
+| select     | dispatched | <code>{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }</code> |
 | change     | forwarded  | --                                                                                              |
 | input      | forwarded  | --                                                                                              |
 | focus      | forwarded  | --                                                                                              |
 | blur       | forwarded  | --                                                                                              |
 | keydown    | forwarded  | --                                                                                              |
-| select     | dispatched | --                                                                                              |
 
 ## `HeaderUtilities`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -10325,15 +10325,14 @@
         { "type": "dispatched", "name": "clear", "detail": "any" },
         {
           "type": "dispatched",
-          "name": "search",
+          "name": "select",
           "detail": "{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }"
         },
         { "type": "forwarded", "name": "change", "element": "input" },
         { "type": "forwarded", "name": "input", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "dispatched", "name": "select" }
+        { "type": "forwarded", "name": "keydown", "element": "input" }
       ],
       "typedefs": [
         {

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1,5 +1,5 @@
 {
-  "total": 154,
+  "total": 155,
   "components": [
     {
       "moduleName": "SkeletonText",
@@ -10257,6 +10257,92 @@
       "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "button" }
+    },
+    {
+      "moduleName": "HeaderSearch",
+      "filePath": "/src/UIShell/HeaderSearch.svelte",
+      "props": [
+        {
+          "name": "value",
+          "kind": "let",
+          "description": "Specify the search input value",
+          "type": "string",
+          "value": "\"\"",
+          "isFunction": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
+          "name": "active",
+          "kind": "let",
+          "description": "Set to `true` to activate and focus the search bar",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
+          "name": "ref",
+          "kind": "let",
+          "description": "Obtain a reference to the input HTML element",
+          "type": "null | HTMLInputElement",
+          "value": "null",
+          "isFunction": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
+          "name": "results",
+          "kind": "let",
+          "description": "Render a list of search results",
+          "type": "HeaderSearchResult[]",
+          "value": "[]",
+          "isFunction": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "selectedResultIndex",
+          "kind": "let",
+          "description": "Specify the selected result index",
+          "type": "number",
+          "value": "-1",
+          "isFunction": false,
+          "constant": false,
+          "reactive": true
+        }
+      ],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "fallback": "{result.text}\n              {#if result.description}<span>– {result.description}</span>{/if}",
+          "slot_props": "{ result: any }"
+        }
+      ],
+      "events": [
+        { "type": "dispatched", "name": "clear", "detail": "any" },
+        {
+          "type": "dispatched",
+          "name": "search",
+          "detail": "{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }"
+        },
+        { "type": "forwarded", "name": "change", "element": "input" },
+        { "type": "forwarded", "name": "input", "element": "input" },
+        { "type": "forwarded", "name": "focus", "element": "input" },
+        { "type": "forwarded", "name": "blur", "element": "input" },
+        { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "dispatched", "name": "select" }
+      ],
+      "typedefs": [
+        {
+          "type": "{ href: string; text: string; description?: string; }",
+          "name": "HeaderSearchResult",
+          "ts": "interface HeaderSearchResult { href: string; text: string; description?: string; }"
+        }
+      ],
+      "rest_props": { "type": "Element", "name": "input" }
     },
     {
       "moduleName": "UnorderedList",

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -10307,7 +10307,7 @@
           "kind": "let",
           "description": "Specify the selected result index",
           "type": "number",
-          "value": "-1",
+          "value": "0",
           "isFunction": false,
           "constant": false,
           "reactive": true
@@ -10318,10 +10318,12 @@
           "name": "__default__",
           "default": true,
           "fallback": "{result.text}\n              {#if result.description}<span>– {result.description}</span>{/if}",
-          "slot_props": "{ result: any }"
+          "slot_props": "{ result: HeaderSearchResult; index: number }"
         }
       ],
       "events": [
+        { "type": "dispatched", "name": "active", "detail": "any" },
+        { "type": "dispatched", "name": "inactive", "detail": "any" },
         { "type": "dispatched", "name": "clear", "detail": "any" },
         {
           "type": "dispatched",

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -4,7 +4,7 @@
 components: ["Header",
 "HeaderAction",
 "HeaderActionLink",
-"HeaderActionSearch",
+"HeaderSearch",
 "HeaderNav",
 "HeaderNavItem",
 "HeaderNavMenu",
@@ -33,6 +33,10 @@ components: ["Header",
 ### Header with app switcher
 
 <FileSource src="/framed/UIShell/HeaderSwitcher" />
+
+### Header with global search
+
+<FileSource src="/framed/UIShell/HeaderSearch" />
 
 ### Header with utilities
 

--- a/docs/src/pages/framed/UIShell/HeaderSearch.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSearch.svelte
@@ -3,7 +3,7 @@
     Header,
     HeaderUtilities,
     HeaderAction,
-    HeaderGlobalAction,
+    HeaderSearch,
     HeaderPanelLinks,
     HeaderPanelDivider,
     HeaderPanelLink,
@@ -18,10 +18,40 @@
     Row,
     Column,
   } from "carbon-components-svelte";
-  import SettingsAdjust20 from "carbon-icons-svelte/lib/SettingsAdjust20";
 
   let isSideNavOpen = false;
   let isOpen = false;
+
+  let ref = null;
+  let active = false;
+  let value = "";
+  let selectedResultIndex = 1;
+
+  $: results =
+    value.length > 2
+      ? [
+          {
+            href: "/",
+            text: "Result 1",
+            description: "Result description",
+          },
+          {
+            href: "/",
+            text: "Result 2",
+            description: "Result description",
+          },
+          {
+            href: "/",
+            text: "Result 3",
+            description: "Result description",
+          },
+        ]
+      : [];
+
+  $: console.log("ref", ref);
+  $: console.log("active", active);
+  $: console.log("value", value);
+  $: console.log("selectedResultIndex", selectedResultIndex);
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
@@ -29,7 +59,22 @@
     <SkipToContent />
   </div>
   <HeaderUtilities>
-    <HeaderGlobalAction aria-label="Settings" icon="{SettingsAdjust20}" />
+    <HeaderSearch
+      bind:ref
+      bind:active
+      bind:value
+      on:search="{(e) => {
+        console.log('on:search', e.detail);
+      }}"
+      on:clear="{() => {
+        console.log('on:clear');
+      }}"
+      on:select="{(e) => {
+        console.log('on:select', e.detail);
+      }}"
+      results="{results}"
+      bind:selectedResultIndex
+    />
     <HeaderAction bind:isOpen>
       <HeaderPanelLinks>
         <HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>

--- a/docs/src/pages/framed/UIShell/HeaderSearch.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSearch.svelte
@@ -7,45 +7,56 @@
     HeaderPanelLinks,
     HeaderPanelDivider,
     HeaderPanelLink,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
     SkipToContent,
     Content,
     Grid,
     Row,
     Column,
+    Button,
   } from "carbon-components-svelte";
 
-  let isSideNavOpen = false;
-  let isOpen = false;
+  const data = [
+    {
+      href: "/",
+      text: "Kubernetes Service",
+      description:
+        "Deploy secure, highly available apps in a native Kubernetes experience. IBM Cloud Kubernetes Service creates a cluster of compute hosts and deploys highly available containers.",
+    },
+    {
+      href: "/",
+      text: "Red Hat OpenShift on IBM Cloud",
+      description:
+        "Deploy and secure enterprise workloads on native OpenShift with developer focused tools to run highly available apps. OpenShift clusters build on Kubernetes container orchestration that offers consistency and flexibility in operations.",
+    },
+    {
+      href: "/",
+      text: "Container Registry",
+      description:
+        "Securely store container images and monitor their vulnerabilities in a private registry.",
+    },
+    {
+      href: "/",
+      text: "Code Engine",
+      description:
+        "Run your application, job, or container on a managed serverless platform.",
+    },
+  ];
 
   let ref = null;
   let active = false;
   let value = "";
-  let selectedResultIndex = 1;
+  let selectedResultIndex = 0;
+  let events = [];
 
+  $: lowerCaseValue = value.toLowerCase();
   $: results =
-    value.length > 2
-      ? [
-          {
-            href: "/",
-            text: "Result 1",
-            description: "Result description",
-          },
-          {
-            href: "/",
-            text: "Result 2",
-            description: "Result description",
-          },
-          {
-            href: "/",
-            text: "Result 3",
-            description: "Result description",
-          },
-        ]
+    value.length > 0
+      ? data.filter((item) => {
+          return (
+            item.text.toLowerCase().includes(lowerCaseValue) ||
+            item.description.includes(lowerCaseValue)
+          );
+        })
       : [];
 
   $: console.log("ref", ref);
@@ -54,7 +65,7 @@
   $: console.log("selectedResultIndex", selectedResultIndex);
 </script>
 
-<Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
+<Header company="IBM" platformName="Carbon Svelte">
   <div slot="skip-to-content">
     <SkipToContent />
   </div>
@@ -64,47 +75,55 @@
       bind:active
       bind:value
       bind:selectedResultIndex
+      placeholder="Search services"
       results="{results}"
+      on:active="{() => {
+        events = [...events, { type: 'active' }];
+      }}"
+      on:inactive="{() => {
+        events = [...events, { type: 'inactive' }];
+      }}"
       on:clear="{() => {
-        console.log('on:clear');
+        events = [...events, { type: 'clear' }];
       }}"
       on:select="{(e) => {
-        console.log('on:select', e.detail);
+        events = [...events, { type: 'select', ...e.detail }];
       }}"
     />
-    <HeaderAction bind:isOpen>
-      <HeaderPanelLinks>
-        <HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>
-        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
-        <HeaderPanelDivider>Switcher subject 2</HeaderPanelDivider>
-        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 2</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 3</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 4</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 5</HeaderPanelLink>
-      </HeaderPanelLinks>
-    </HeaderAction>
   </HeaderUtilities>
 </Header>
-
-<SideNav bind:isOpen="{isSideNavOpen}">
-  <SideNavItems>
-    <SideNavLink text="Link 1" />
-    <SideNavLink text="Link 2" />
-    <SideNavLink text="Link 3" />
-    <SideNavMenu text="Menu">
-      <SideNavMenuItem href="/" text="Link 1" />
-      <SideNavMenuItem href="/" text="Link 2" />
-      <SideNavMenuItem href="/" text="Link 3" />
-    </SideNavMenu>
-  </SideNavItems>
-</SideNav>
 
 <Content>
   <Grid>
     <Row>
       <Column>
-        <h1>Welcome</h1>
+        <h1>HeaderSearch</h1>
+        <Button
+          on:click="{() => {
+            active = true;
+          }}"
+        >
+          Activate the search bar
+        </Button>
+        <h2>Reactive values</h2>
+        <p><strong>active</strong>: {active}</p>
+        <p><strong>value</strong>: {value}</p>
+        <p><strong>selectedResultIndex</strong>: {selectedResultIndex}</p>
+        <h2>Events</h2>
+        <p>
+          Click the button and search for something. Dispatched events are
+          logged below:
+        </p>
+        <div style="overflow-x: scroll;">
+          {#each events as { type, ...rest }}
+            <div style="display: block; margin-bottom: var(--cds-layout-01)">
+              <div><strong>on:{type}</strong></div>
+              {#if Object.keys(rest).length > 0}
+                <pre>{JSON.stringify(rest, null, 2)}</pre>
+              {/if}
+            </div>
+          {/each}
+        </div>
       </Column>
     </Row>
   </Grid>

--- a/docs/src/pages/framed/UIShell/HeaderSearch.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSearch.svelte
@@ -63,17 +63,14 @@
       bind:ref
       bind:active
       bind:value
-      on:search="{(e) => {
-        console.log('on:search', e.detail);
-      }}"
+      bind:selectedResultIndex
+      results="{results}"
       on:clear="{() => {
         console.log('on:clear');
       }}"
       on:select="{(e) => {
         console.log('on:select', e.detail);
       }}"
-      results="{results}"
-      bind:selectedResultIndex
     />
     <HeaderAction bind:isOpen>
       <HeaderPanelLinks>

--- a/src/UIShell/GlobalHeader/HeaderActionSearch.svelte
+++ b/src/UIShell/GlobalHeader/HeaderActionSearch.svelte
@@ -1,5 +1,11 @@
 <script>
   /**
+   * @deprecated
+   * This component will be removed in version 1.0.0.
+   * Use `HeaderSearch` instead
+   */
+
+  /**
    * @event {{ action: "search"; textInput: string; }} inputSearch
    */
 

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -5,6 +5,7 @@
    * @event {any} inactive
    * @event {any} clear
    * @event {{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }} select
+   * @slot {{ result: HeaderSearchResult; index: number }}
    */
 
   /** Specify the search input value */
@@ -271,7 +272,7 @@
             class:selected="{selectedId === `search-menuitem-${i}`}"
             on:click|preventDefault="{selectResult}"
           >
-            <slot result="{result}">
+            <slot result="{result}" index="{i}">
               {result.text}
               {#if result.description}<span>– {result.description}</span>{/if}
             </slot>

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -31,6 +31,12 @@
 
   let refSearch = null;
 
+  function selectResult() {
+    active = false;
+    value = "";
+    dispatch("select", { value, selectedResultIndex, selectedResult });
+  }
+
   $: if (active && ref) ref.focus();
   $: selectedResult = results[selectedResultIndex];
   $: selectedId = selectedResult
@@ -211,9 +217,7 @@
       on:keydown="{({ key }) => {
         switch (key) {
           case 'Enter':
-            active = false;
-            value = '';
-            dispatch('select', { value, selectedResultIndex, selectedResult });
+            selectResult();
             break;
           case 'ArrowDown':
             if (selectedResultIndex === results.length - 1) {
@@ -258,13 +262,7 @@
             role="menuitem"
             href="{result.href}"
             class:selected="{selectedId === `search-menuitem-${i}`}"
-            on:click|preventDefault="{() => {
-              dispatch('select', {
-                value,
-                selectedResultIndex,
-                selectedResult,
-              });
-            }}"
+            on:click|preventDefault="{selectResult}"
           >
             <slot result="{result}">
               {result.text}

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -2,7 +2,7 @@
   /**
    * @typedef {{ href: string; text: string; description?: string; }} HeaderSearchResult
    * @event {any} clear
-   * @event {{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }} search
+   * @event {{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }} select
    */
 
   /** Specify the search input value */

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -1,6 +1,8 @@
 <script>
   /**
    * @typedef {{ href: string; text: string; description?: string; }} HeaderSearchResult
+   * @event {any} active
+   * @event {any} inactive
    * @event {any} clear
    * @event {{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }} select
    */
@@ -21,7 +23,7 @@
   export let results = [];
 
   /** Specify the selected result index */
-  export let selectedResultIndex = -1;
+  export let selectedResultIndex = 0;
 
   import { createEventDispatcher } from "svelte";
   import Close20 from "carbon-icons-svelte/lib/Close20/Close20.svelte";
@@ -31,13 +33,19 @@
 
   let refSearch = null;
 
-  function selectResult() {
+  function reset() {
     active = false;
     value = "";
+    selectedResultIndex = 0;
+  }
+
+  function selectResult() {
     dispatch("select", { value, selectedResultIndex, selectedResult });
+    reset();
   }
 
   $: if (active && ref) ref.focus();
+  $: dispatch(active ? "active" : "inactive");
   $: selectedResult = results[selectedResultIndex];
   $: selectedId = selectedResult
     ? `search-menuitem-${selectedResultIndex}`
@@ -243,8 +251,7 @@
       class:bx--header__action="{true}"
       class:hidden="{!active}"
       on:click="{() => {
-        active = false;
-        value = '';
+        reset();
         dispatch('clear');
       }}"
     >

--- a/src/UIShell/index.js
+++ b/src/UIShell/index.js
@@ -17,3 +17,4 @@ export { default as SideNavMenuItem } from "./SideNav/SideNavMenuItem.svelte";
 export { default as Content } from "./Content.svelte";
 export { default as SkipToContent } from "./SkipToContent.svelte";
 export { default as HeaderGlobalAction } from "./HeaderGlobalAction.svelte";
+export { default as HeaderSearch } from "./HeaderSearch.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -134,5 +134,6 @@ export {
   Content,
   SkipToContent,
   HeaderGlobalAction,
+  HeaderSearch,
 } from "./UIShell";
 export { UnorderedList } from "./UnorderedList";

--- a/tests/HeaderSearch.svelte
+++ b/tests/HeaderSearch.svelte
@@ -73,7 +73,11 @@
       on:select="{(e) => {
         console.log('on:select', e.detail);
       }}"
-    />
+      let:result
+      let:index
+    >
+      <div>{result.text}{index}</div>
+    </HeaderSearch>
     <HeaderAction bind:isOpen>
       <HeaderPanelLinks>
         <HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>

--- a/tests/HeaderSearch.svelte
+++ b/tests/HeaderSearch.svelte
@@ -65,6 +65,8 @@
       bind:value
       bind:selectedResultIndex
       results="{results}"
+      on:active
+      on:inactive
       on:clear="{() => {
         console.log('on:clear');
       }}"

--- a/tests/HeaderSearch.svelte
+++ b/tests/HeaderSearch.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import {
+    Header,
+    HeaderUtilities,
+    HeaderAction,
+    HeaderSearch,
+    HeaderPanelLinks,
+    HeaderPanelDivider,
+    HeaderPanelLink,
+    SideNav,
+    SideNavItems,
+    SideNavMenu,
+    SideNavMenuItem,
+    SideNavLink,
+    SkipToContent,
+    Content,
+    Grid,
+    Row,
+    Column,
+  } from "../types";
+
+  let isSideNavOpen = false;
+  let isOpen = false;
+
+  let ref = null;
+  let active = false;
+  let value = "";
+  let selectedResultIndex = 1;
+
+  $: results =
+    value.length > 2
+      ? [
+          {
+            href: "/",
+            text: "Result 1",
+            description: "Result description",
+          },
+          {
+            href: "/",
+            text: "Result 2",
+            description: "Result description",
+          },
+          {
+            href: "/",
+            text: "Result 3",
+            description: "Result description",
+          },
+        ]
+      : [];
+
+  $: console.log("ref", ref);
+  $: console.log("active", active);
+  $: console.log("value", value);
+  $: console.log("selectedResultIndex", selectedResultIndex);
+</script>
+
+<Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
+  <div slot="skip-to-content">
+    <SkipToContent />
+  </div>
+  <HeaderUtilities>
+    <HeaderSearch
+      bind:ref
+      bind:active
+      bind:value
+      bind:selectedResultIndex
+      results="{results}"
+      on:clear="{() => {
+        console.log('on:clear');
+      }}"
+      on:select="{(e) => {
+        console.log('on:select', e.detail);
+      }}"
+    />
+    <HeaderAction bind:isOpen>
+      <HeaderPanelLinks>
+        <HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>
+        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
+        <HeaderPanelDivider>Switcher subject 2</HeaderPanelDivider>
+        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
+        <HeaderPanelLink>Switcher item 2</HeaderPanelLink>
+        <HeaderPanelLink>Switcher item 3</HeaderPanelLink>
+        <HeaderPanelLink>Switcher item 4</HeaderPanelLink>
+        <HeaderPanelLink>Switcher item 5</HeaderPanelLink>
+      </HeaderPanelLinks>
+    </HeaderAction>
+  </HeaderUtilities>
+</Header>
+
+<SideNav bind:isOpen="{isSideNavOpen}">
+  <SideNavItems>
+    <SideNavLink text="Link 1" />
+    <SideNavLink text="Link 2" />
+    <SideNavLink text="Link 3" />
+    <SideNavMenu text="Menu">
+      <SideNavMenuItem href="/" text="Link 1" />
+      <SideNavMenuItem href="/" text="Link 2" />
+      <SideNavMenuItem href="/" text="Link 3" />
+    </SideNavMenu>
+  </SideNavItems>
+</SideNav>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <h1>Welcome</h1>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/types/UIShell/HeaderSearch.d.ts
+++ b/types/UIShell/HeaderSearch.d.ts
@@ -46,7 +46,7 @@ export default class HeaderSearch {
 
   $on(eventname: "clear", cb: (event: CustomEvent<any>) => void): () => void;
   $on(
-    eventname: "search",
+    eventname: "select",
     cb: (event: CustomEvent<{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }>) => void
   ): () => void;
   $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
@@ -54,6 +54,5 @@ export default class HeaderSearch {
   $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
   $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
   $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
-  $on(eventname: "select", cb: (event: CustomEvent<any>) => void): () => void;
   $on(eventname: string, cb: (event: Event) => void): () => void;
 }

--- a/types/UIShell/HeaderSearch.d.ts
+++ b/types/UIShell/HeaderSearch.d.ts
@@ -33,7 +33,7 @@ export interface HeaderSearchProps extends svelte.JSX.HTMLAttributes<HTMLElement
 
   /**
    * Specify the selected result index
-   * @default -1
+   * @default 0
    */
   selectedResultIndex?: number;
 }
@@ -41,9 +41,11 @@ export interface HeaderSearchProps extends svelte.JSX.HTMLAttributes<HTMLElement
 export default class HeaderSearch {
   $$prop_def: HeaderSearchProps;
   $$slot_def: {
-    default: { result: any };
+    default: { result: HeaderSearchResult; index: number };
   };
 
+  $on(eventname: "active", cb: (event: CustomEvent<any>) => void): () => void;
+  $on(eventname: "inactive", cb: (event: CustomEvent<any>) => void): () => void;
   $on(eventname: "clear", cb: (event: CustomEvent<any>) => void): () => void;
   $on(
     eventname: "select",

--- a/types/UIShell/HeaderSearch.d.ts
+++ b/types/UIShell/HeaderSearch.d.ts
@@ -1,0 +1,59 @@
+/// <reference types="svelte" />
+
+export interface HeaderSearchResult {
+  href: string;
+  text: string;
+  description?: string;
+}
+
+export interface HeaderSearchProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
+  /**
+   * Specify the search input value
+   * @default ""
+   */
+  value?: string;
+
+  /**
+   * Set to `true` to activate and focus the search bar
+   * @default false
+   */
+  active?: boolean;
+
+  /**
+   * Obtain a reference to the input HTML element
+   * @default null
+   */
+  ref?: null | HTMLInputElement;
+
+  /**
+   * Render a list of search results
+   * @default []
+   */
+  results?: HeaderSearchResult[];
+
+  /**
+   * Specify the selected result index
+   * @default -1
+   */
+  selectedResultIndex?: number;
+}
+
+export default class HeaderSearch {
+  $$prop_def: HeaderSearchProps;
+  $$slot_def: {
+    default: { result: any };
+  };
+
+  $on(eventname: "clear", cb: (event: CustomEvent<any>) => void): () => void;
+  $on(
+    eventname: "search",
+    cb: (event: CustomEvent<{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }>) => void
+  ): () => void;
+  $on(eventname: "change", cb: (event: WindowEventMap["change"]) => void): () => void;
+  $on(eventname: "input", cb: (event: WindowEventMap["input"]) => void): () => void;
+  $on(eventname: "focus", cb: (event: WindowEventMap["focus"]) => void): () => void;
+  $on(eventname: "blur", cb: (event: WindowEventMap["blur"]) => void): () => void;
+  $on(eventname: "keydown", cb: (event: WindowEventMap["keydown"]) => void): () => void;
+  $on(eventname: "select", cb: (event: CustomEvent<any>) => void): () => void;
+  $on(eventname: string, cb: (event: Event) => void): () => void;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -151,4 +151,5 @@ export { default as SideNavMenuItem } from "./UIShell/SideNav/SideNavMenuItem";
 export { default as Content } from "./UIShell/Content";
 export { default as SkipToContent } from "./UIShell/SkipToContent";
 export { default as HeaderGlobalAction } from "./UIShell/HeaderGlobalAction";
+export { default as HeaderSearch } from "./UIShell/HeaderSearch";
 export { default as UnorderedList } from "./UnorderedList/UnorderedList";


### PR DESCRIPTION
#395 

**Changes**

- add a highly reactive HeaderSearch component that can render user-provided results
- deprecate HeaderActionSearch in favor of HeaderSearch

Sample usage:

```svelte
<script>
  let ref = null;
  let active = false;
  let value = "";
  let selectedResultIndex = 1;

  $: results =
    value.length > 2
      ? [
          {
            href: "/",
            text: "Result 1",
            description: "Result description",
          },
          {
            href: "/",
            text: "Result 2",
            description: "Result description",
          },
          {
            href: "/",
            text: "Result 3",
            description: "Result description",
          },
        ]
      : [];

    $: console.log("ref", ref);
    $: console.log("active", active);
    $: console.log("value", value);
    $: console.log("selectedResultIndex", selectedResultIndex);
</script>

<HeaderSearch
      bind:ref
      bind:active
      bind:value
      bind:selectedResultIndex
      results="{results}"
      on:clear
      on:select="{(e) => {
        console.log('on:select', e.detail);
      }}"
    />
```

**Documentation**

- add "Header with global search" example

**Todo**

- [x] validate TypeScript types
- [ ] ~add recipes for search results~