### PR TITLE
fix(select-item): revert spreading rest props

### DIFF
--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -32,7 +32,8 @@
   hidden="{hidden}"
   selected="{selected}"
   class:bx--select-option="{true}"
-  {...$$restProps}
+  class="{$$restProps.class}"
+  style="{$$restProps.style}"
 >
   {text || value}
 </option>


### PR DESCRIPTION
Fixes #451 

Reverts https://github.com/IBM/carbon-components-svelte/pull/449/commits/90bd2a10b7c00c3eb29d205d1945ed80db5975b5#diff-12cef3c45879191131821aeebbb60be97d60888f43daf6dce4a419537538945d
