### PR TITLE
Overflow menu first time open behavior is not correct

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -125,9 +125,11 @@
       }
     }
 
-    items.set([]);
-    currentId.set(undefined);
-    currentIndex.set(0);
+    if (!open) {
+      items.set([]);
+      currentId.set(undefined);
+      currentIndex.set(0);
+    }
 
     onMountAfterUpdate = false;
   });

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -187,13 +187,6 @@
       }
     }
   }}"
-  on:focusout="{(e) => {
-    if (open) {
-      if (!buttonRef.contains(e.relatedTarget)) {
-        open = false;
-      }
-    }
-  }}"
 >
   <slot name="menu">
     <svelte:component

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -66,7 +66,7 @@
   const currentIndex = writable(-1);
 
   let buttonWidth = undefined;
-  let didOpen = false;
+  let onMountAfterUpdate = true;
 
   setContext("OverflowMenu", {
     focusedId,
@@ -108,7 +108,7 @@
 
       buttonWidth = width;
 
-      if ($currentIndex < 0) {
+      if (!onMountAfterUpdate && $currentIndex < 0) {
         menuRef.focus();
       }
 
@@ -125,15 +125,11 @@
       }
     }
 
-    if (didOpen && !open) {
-      items.set([]);
-      currentId.set(undefined);
-      currentIndex.set(0);
-    }
+    items.set([]);
+    currentId.set(undefined);
+    currentIndex.set(0);
 
-    if (!didOpen && open) {
-      didOpen = true;
-    }
+    onMountAfterUpdate = false;
   });
 
   $: ariaLabel = $$props["aria-label"] || "menu";

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -191,6 +191,13 @@
       }
     }
   }}"
+  on:focusout="{(e) => {
+    if (open) {
+      if (!buttonRef.contains(e.relatedTarget)) {
+        open = false;
+      }
+    }
+  }}"
 >
   <slot name="menu">
     <svelte:component


### PR DESCRIPTION
This PR contains a fix for issue #476 

The current implementation prevents the focus to be set when it is opened for the first time. The code in this PR prevents the focus to be set during the initial after update lifecycle method call. The initial lifecycle call is called after the component is mounted.