### PR TITLE
Minor fixes to align with v10.26

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -43,7 +43,6 @@
   <Search
     size="sm"
     tabindex="{expanded ? tabindex : '-1'}"
-    aria-hidden="{!expanded}"
     {...$$restProps}
     bind:ref
     bind:value

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -95,6 +95,7 @@
     value = nextValue;
   }
 
+  $: labelId = `label-${id}`;
   $: range = max - min;
   $: left = ((value - min) / range) * 100;
   $: {
@@ -132,6 +133,7 @@
 >
   <label
     for="{id}"
+    id="{labelId}"
     class:bx--label="{true}"
     class:bx--label--disabled="{disabled}"
   >
@@ -160,6 +162,7 @@
         tabindex="0"
         class:bx--slider__thumb="{true}"
         style="left: {left}%"
+        aria-labelledby="{labelId}"
         aria-valuemax="{max}"
         aria-valuemin="{min}"
         aria-valuenow="{value}"

--- a/src/UIShell/GlobalHeader/HeaderNav.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNav.svelte
@@ -1,17 +1,19 @@
 <script>
   /**
    * Specify the ARIA label for the nav
+   * @deprecated use "aria-label" instead
    * @type {string}
    */
   export let ariaLabel = undefined;
+
+  $: props = {
+    "aria-label": ariaLabel || $$props["aria-label"],
+    "aria-labelledby": $$props["aria-labelledby"],
+  };
 </script>
 
-<nav aria-label="{ariaLabel}" class:bx--header__nav="{true}" {...$$restProps}>
-  <ul
-    role="menubar"
-    aria-label="{ariaLabel}"
-    class:bx--header__menu-bar="{true}"
-  >
+<nav {...props} class:bx--header__nav="{true}" {...$$restProps}>
+  <ul {...props} class:bx--header__menu-bar="{true}">
     <slot />
   </ul>
 </nav>


### PR DESCRIPTION
Non-style related fixes from the upstream Carbon library.

**Fixes**

- remove "aria-hidden" prop from ToolbarSearch
- remove "menubar" role from HeaderNav; deprecate ariaLabel in favor of native attributes "aria-label" and "aria-labelledby"
- add label id to Slider