### PR TITLE
fix(modal): remove extraneous focus ring

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -90,7 +90,6 @@
 <div
   bind:this="{ref}"
   role="presentation"
-  tabindex="-1"
   class:bx--modal="{true}"
   class:is-visible="{open}"
   class:bx--modal--danger="{danger}"

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -127,7 +127,6 @@
 <div
   bind:this="{ref}"
   role="presentation"
-  tabindex="-1"
   id="{id}"
   class:bx--modal="{true}"
   class:bx--modal-tall="{!passiveModal}"
@@ -156,6 +155,7 @@
   <div
     bind:this="{innerModal}"
     role="dialog"
+    tabindex="-1"
     {...alertDialogProps}
     aria-modal="true"
     aria-label="{ariaLabel}"


### PR DESCRIPTION
An extraneous focus ring for the Modal component is caused by `tabindex="-1"` being set on the incorrect element.

**Fixes**

- move `tabindex="-1"` to the body elemennt in Modal
- remove `tabindex="-1"` from ComposedModal (ModalBody already sets `tabindex`)