### PR TITLE
add OutboundLink

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2376,7 +2376,12 @@ None.
 
 ### Events
 
-None.
+| Event name | Type      | Detail |
+| :--------- | :-------- | :----- |
+| click      | forwarded | --     |
+| mouseover  | forwarded | --     |
+| mouseenter | forwarded | --     |
+| mouseleave | forwarded | --     |
 
 ## `OverflowMenu`
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1,6 +1,6 @@
 # Component Index
 
-> 155 components exported from carbon-components-svelte@0.27.0.
+> 156 components exported from carbon-components-svelte@0.27.0.
 
 ## Components
 
@@ -84,6 +84,7 @@
 - [`NumberInput`](#numberinput)
 - [`NumberInputSkeleton`](#numberinputskeleton)
 - [`OrderedList`](#orderedlist)
+- [`OutboundLink`](#outboundlink)
 - [`OverflowMenu`](#overflowmenu)
 - [`OverflowMenuItem`](#overflowmenuitem)
 - [`Pagination`](#pagination)
@@ -2360,6 +2361,22 @@ None.
 | mouseover  | forwarded | --     |
 | mouseenter | forwarded | --     |
 | mouseleave | forwarded | --     |
+
+## `OutboundLink`
+
+### Props
+
+None.
+
+### Slots
+
+| Slot name | Default | Props | Fallback |
+| :-------- | :------ | :---- | :------- |
+| --        | Yes     | --    | --       |
+
+### Events
+
+None.
 
 ## `OverflowMenu`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -5088,7 +5088,12 @@
       "filePath": "/src/Link/OutboundLink.svelte",
       "props": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
-      "events": [],
+      "events": [
+        { "type": "forwarded", "name": "click", "element": "Link" },
+        { "type": "forwarded", "name": "mouseover", "element": "Link" },
+        { "type": "forwarded", "name": "mouseenter", "element": "Link" },
+        { "type": "forwarded", "name": "mouseleave", "element": "Link" }
+      ],
       "typedefs": [],
       "rest_props": { "type": "InlineComponent", "name": "Link" },
       "extends": { "interface": "LinkProps", "import": "\"./Link\"" }

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1,5 +1,5 @@
 {
-  "total": 155,
+  "total": 156,
   "components": [
     {
       "moduleName": "SkeletonText",
@@ -5082,6 +5082,16 @@
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }
+    },
+    {
+      "moduleName": "OutboundLink",
+      "filePath": "/src/Link/OutboundLink.svelte",
+      "props": [],
+      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "events": [],
+      "typedefs": [],
+      "rest_props": { "type": "InlineComponent", "name": "Link" },
+      "extends": { "interface": "LinkProps", "import": "\"./Link\"" }
     },
     {
       "moduleName": "ListItem",

--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -1,5 +1,5 @@
 <script>
-  import { Link } from "carbon-components-svelte";
+  import { Link, OutboundLink } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
 </script>
 
@@ -9,13 +9,17 @@
 
 ### Target _blank
 
-Setting `target` to `"_blank"` opens the link in a new tab.
-
-If `target="_blank"`, the `Link` component will automatically set `rel="noopener noreferrer"` to guard against [potential cross-origin security exploits](https://web.dev/external-anchors-use-rel-noopener/).
+If setting `target` to `"_blank"`, the `Link` component will automatically set `rel="noopener noreferrer"` to guard against [potential cross-origin security exploits](https://web.dev/external-anchors-use-rel-noopener/).
 
 You can override the `rel` attribute with a custom value.
 
 <Link href="https://www.carbondesignsystem.com/" target="_blank">Carbon Design System</Link>
+
+### Outbound link
+
+An alternative to manually setting `target` to `"_blank"` is to use the `OutboundLink`.
+
+<OutboundLink href="https://www.carbondesignsystem.com/">Carbon Design System</OutboundLink>
 
 ### Inline variant
 

--- a/src/Link/OutboundLink.svelte
+++ b/src/Link/OutboundLink.svelte
@@ -1,0 +1,11 @@
+<script>
+  /** @extends {"./Link"} LinkProps */
+
+  import Link from "./Link.svelte";
+  import Launch16 from "carbon-icons-svelte/lib/Launch16/Launch16.svelte";
+</script>
+
+<Link {...$$restProps} target="_blank">
+  <slot />
+  <Launch16 />
+</Link>

--- a/src/Link/OutboundLink.svelte
+++ b/src/Link/OutboundLink.svelte
@@ -5,7 +5,14 @@
   import Launch16 from "carbon-icons-svelte/lib/Launch16/Launch16.svelte";
 </script>
 
-<Link {...$$restProps} target="_blank">
+<Link
+  {...$$restProps}
+  on:click
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
+  target="_blank"
+>
   <slot />
   <Launch16 />
 </Link>

--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -1,1 +1,2 @@
 export { default as Link } from "./Link.svelte";
+export { default as OutboundLink } from "./OutboundLink.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ export { FormLabel } from "./FormLabel";
 export { Grid, Row, Column } from "./Grid";
 export { Icon, IconSkeleton } from "./Icon";
 export { InlineLoading } from "./InlineLoading";
-export { Link } from "./Link";
+export { Link, OutboundLink } from "./Link";
 export {
   ListBox,
   ListBoxField,

--- a/types/Link/OutboundLink.d.ts
+++ b/types/Link/OutboundLink.d.ts
@@ -9,5 +9,9 @@ export default class OutboundLink {
     default: {};
   };
 
+  $on(eventname: "click", cb: (event: WindowEventMap["click"]) => void): () => void;
+  $on(eventname: "mouseover", cb: (event: WindowEventMap["mouseover"]) => void): () => void;
+  $on(eventname: "mouseenter", cb: (event: WindowEventMap["mouseenter"]) => void): () => void;
+  $on(eventname: "mouseleave", cb: (event: WindowEventMap["mouseleave"]) => void): () => void;
   $on(eventname: string, cb: (event: Event) => void): () => void;
 }

--- a/types/Link/OutboundLink.d.ts
+++ b/types/Link/OutboundLink.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="svelte" />
+import { LinkProps } from "./Link";
+
+export interface OutboundLinkProps extends LinkProps {}
+
+export default class OutboundLink {
+  $$prop_def: OutboundLinkProps;
+  $$slot_def: {
+    default: {};
+  };
+
+  $on(eventname: string, cb: (event: Event) => void): () => void;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,6 +73,7 @@ export { default as Column } from "./Grid/Column";
 export { default as IconSkeleton } from "./Icon/IconSkeleton";
 export { default as Icon } from "./Icon/Icon";
 export { default as InlineLoading } from "./InlineLoading/InlineLoading";
+export { default as OutboundLink } from "./Link/OutboundLink";
 export { default as ListItem } from "./ListItem/ListItem";
 export { default as MultiSelect } from "./MultiSelect/MultiSelect";
 export { default as Modal } from "./Modal/Modal";


### PR DESCRIPTION
`OutboundLink` wraps `Link` with the following differences:

- target="_blank" is automatically set
- the Launch16 icon is used

```svelte
<OutboundLink href="https://www.carbondesignsystem.com/">Carbon Design System</OutboundLink>
```