### PR TITLE
Fix path to source

### DIFF
--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -30,7 +30,7 @@
     Date: "JavaScript Date",
   };
 
-  $: source = `https://github.com/IBM/carbon-components-svelte/tree/master${component.filePath}`;
+  $: source = `https://github.com/IBM/carbon-components-svelte/tree/master/${component.filePath}`;
   $: forwarded_events = component.events.filter(
     (event) => event.type === "forwarded"
   );


### PR DESCRIPTION
The path to the source is missing a slash.

Before:
`https://github.com/IBM/carbon-components-svelte/tree/mastersrc/Grid/Grid.svelte`

After:
`https://github.com/IBM/carbon-components-svelte/tree/master/src/Grid/Grid.svelte`
`-----------------------------------------------------------^`
