### PR TITLE
fix(scss): use new component tokens to render low contrast notifications

### DIFF
--- a/css/all.scss
+++ b/css/all.scss
@@ -18,21 +18,45 @@ $css--plex: true;
 
 // Use all Carbon themes
 @import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+@import "carbon-components/scss/globals/scss/component-tokens";
+@import "carbon-components/src/components/tag/tag";
+@import "carbon-components/src/components/notification/inline-notification";
+@import "carbon-components/src/components/notification/toast-notification";
 
 // The default theme is "white" (White)
-:root { @include carbon--theme($carbon--theme--white, true); }
+:root {
+  @include carbon--theme($carbon--theme--white, true) {
+    @include emit-component-tokens($tag-colors);
+    @include emit-component-tokens($notification-colors);
+  }
+}
 
 // Set the <html> theme attribute to "g10" to use the Gray 10 theme
 // <html theme="g10">
-:root[theme="g10"] { @include carbon--theme($carbon--theme--g10, true); }
+:root[theme="g10"] {
+  @include carbon--theme($carbon--theme--g10, true) {
+    @include emit-component-tokens($tag-colors);
+    @include emit-component-tokens($notification-colors);
+  }
+}
 
 // Set the <html> theme attribute to "g90" to use the Gray 90 theme
 // <html theme="g90">
-:root[theme="g90"] { @include carbon--theme($carbon--theme--g90, true); }
+:root[theme="g90"] {
+  @include carbon--theme($carbon--theme--g90, true) {
+    @include emit-component-tokens($tag-colors);
+    @include emit-component-tokens($notification-colors);
+  }
+}
 
 // Set the <html> theme attribute to "g100" to use the Gray 100 theme
 // <html theme="g100">
-:root[theme="g100"] { @include carbon--theme($carbon--theme--g100, true); }
+:root[theme="g100"] {
+  @include carbon--theme($carbon--theme--g100, true) {
+    @include emit-component-tokens($tag-colors);
+    @include emit-component-tokens($notification-colors);
+  }
+}
 
 // Programmatically update the theme in JavaScript:
 // document.documentElement.setAttribute("theme", "g90");
@@ -45,4 +69,3 @@ $css--plex: true;
 
 // Import all component styles
 @import "carbon-components/scss/globals/scss/styles";
-

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -13,6 +13,10 @@ $css--plex: true;
 
 // Use the "g10" (Gray 10) Carbon theme
 @import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+@import "carbon-components/scss/globals/scss/component-tokens";
+@import "carbon-components/src/components/tag/tag";
+@import "carbon-components/src/components/notification/inline-notification";
+@import "carbon-components/src/components/notification/toast-notification";
 
 $carbon--theme: $carbon--theme--g10;
 @include carbon--theme();

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -13,6 +13,10 @@ $css--plex: true;
 
 // Use the "g100" (Gray 100) Carbon theme
 @import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+@import "carbon-components/scss/globals/scss/component-tokens";
+@import "carbon-components/src/components/tag/tag";
+@import "carbon-components/src/components/notification/inline-notification";
+@import "carbon-components/src/components/notification/toast-notification";
 
 $carbon--theme: $carbon--theme--g100;
 @include carbon--theme();

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -13,6 +13,10 @@ $css--plex: true;
 
 // Use the "g90" (Gray 90) Carbon theme
 @import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+@import "carbon-components/scss/globals/scss/component-tokens";
+@import "carbon-components/src/components/tag/tag";
+@import "carbon-components/src/components/notification/inline-notification";
+@import "carbon-components/src/components/notification/toast-notification";
 
 $carbon--theme: $carbon--theme--g90;
 @include carbon--theme();

--- a/css/white.scss
+++ b/css/white.scss
@@ -13,6 +13,10 @@ $css--plex: true;
 
 // Use the "white" (White) Carbon theme
 @import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+@import "carbon-components/scss/globals/scss/component-tokens";
+@import "carbon-components/src/components/tag/tag";
+@import "carbon-components/src/components/notification/inline-notification";
+@import "carbon-components/src/components/notification/toast-notification";
 
 $carbon--theme: $carbon--theme--white;
 @include carbon--theme();

--- a/docs/src/App.svelte
+++ b/docs/src/App.svelte
@@ -26,28 +26,44 @@
 
   // Use all Carbon themes
   @import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+  @import "carbon-components/scss/globals/scss/component-tokens";
+  @import "carbon-components/src/components/tag/tag";
+  @import "carbon-components/src/components/notification/inline-notification";
+  @import "carbon-components/src/components/notification/toast-notification";
 
   // The default theme is "white" (White)
   :root {
-    @include carbon--theme($carbon--theme--white, true);
+    @include carbon--theme($carbon--theme--white, true) {
+      @include emit-component-tokens($tag-colors);
+      @include emit-component-tokens($notification-colors);
+    }
   }
 
   // Set the <html> theme attribute to "g10" to use the Gray 10 theme
   // <html theme="g10">
   :root[theme="g10"] {
-    @include carbon--theme($carbon--theme--g10, true);
+    @include carbon--theme($carbon--theme--g10, true) {
+      @include emit-component-tokens($tag-colors);
+      @include emit-component-tokens($notification-colors);
+    }
   }
 
   // Set the <html> theme attribute to "g90" to use the Gray 90 theme
   // <html theme="g90">
   :root[theme="g90"] {
-    @include carbon--theme($carbon--theme--g90, true);
+    @include carbon--theme($carbon--theme--g90, true) {
+      @include emit-component-tokens($tag-colors);
+      @include emit-component-tokens($notification-colors);
+    }
   }
 
   // Set the <html> theme attribute to "g100" to use the Gray 100 theme
   // <html theme="g100">
   :root[theme="g100"] {
-    @include carbon--theme($carbon--theme--g100, true);
+    @include carbon--theme($carbon--theme--g100, true) {
+      @include emit-component-tokens($tag-colors);
+      @include emit-component-tokens($notification-colors);
+    }
   }
 
   // Programmatically update the theme in JavaScript:


### PR DESCRIPTION
This is a hot fix needed to correctly render the text color for low contrast notifications.