### PR TITLE
hotfix: blur ComboBox, MultiSelect focus based on relatedTarget tag name

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -238,6 +238,7 @@
         on:blur="{({ relatedTarget }) => {
           if (!open || !relatedTarget) return;
           if (
+            !['INPUT', 'SELECT', 'TEXTAREA'].includes(relatedTarget.tagName) &&
             relatedTarget.getAttribute('role') !== 'button' &&
             relatedTarget.getAttribute('role') !== 'searchbox'
           ) {

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -238,6 +238,7 @@
         on:blur="{({ relatedTarget }) => {
           if (!open || !relatedTarget) return;
           if (
+            relatedTarget &&
             !['INPUT', 'SELECT', 'TEXTAREA'].includes(relatedTarget.tagName) &&
             relatedTarget.getAttribute('role') !== 'button' &&
             relatedTarget.getAttribute('role') !== 'searchbox'

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -316,7 +316,12 @@
         }
       }}"
       on:blur="{({ relatedTarget }) => {
-        if (relatedTarget && relatedTarget.getAttribute('role') !== 'button') {
+        if (
+          relatedTarget &&
+          !['INPUT', 'SELECT', 'TEXTAREA'].includes(relatedTarget.tagName) &&
+          relatedTarget.getAttribute('role') !== 'button' &&
+          relatedTarget.getAttribute('role') !== 'searchbox'
+        ) {
           fieldRef.focus();
         }
       }}"


### PR DESCRIPTION
When blurring (e.g., clicking away from) a ComboBox or MultiSelect, the list box should *not* be re-focused if the related target is an input/select/textarea element.