### PR TITLE
fix(button): remove blank line to correctly render button with icon in Safari 13

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -137,8 +137,7 @@
     {#if hasIconOnly}
       <span class:bx--assistive-text="{true}">{iconDescription}</span>
     {/if}
-    <slot />
-    <svelte:component
+    <slot /><svelte:component
       this="{icon}"
       aria-hidden="true"
       class="bx--btn__icon"
@@ -157,8 +156,7 @@
     {#if hasIconOnly}
       <span class:bx--assistive-text="{true}">{iconDescription}</span>
     {/if}
-    <slot />
-    <svelte:component
+    <slot /><svelte:component
       this="{icon}"
       aria-hidden="true"
       class="bx--btn__icon"


### PR DESCRIPTION
Icons in the "Button w/ icon" variant incorrectly renders in Safari 13.

The fix is to remove the blank space between the slot and icon.