### PR TITLE
NumberInput: forward name to non-mobile variant

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -249,6 +249,7 @@
           aria-label="{label ? undefined : ariaLabel}"
           disabled="{disabled}"
           id="{id}"
+          name="{name}"
           max="{max}"
           min="{min}"
           step="{step}"


### PR DESCRIPTION
NumberInput does not set `name` property correctly on the non-mobile variant. 