### PR TITLE
hotfix: reset input background color to use $field-01

### DIFF
--- a/docs/src/App.svelte
+++ b/docs/src/App.svelte
@@ -77,4 +77,16 @@
 
   // Import all component styles
   @import "carbon-components/scss/globals/scss/styles";
+
+  .bx--list-box:not(.bx--list-box--light) input[role="combobox"],
+  .bx--list-box:not(.bx--list-box--light) input[type="text"],
+  .bx--dropdown:not(.bx--dropdown--light),
+  .bx--list-box:not(.bx--list-box--light),
+  .bx--number:not(.bx--number--light) input[type="number"],
+  .bx--number:not(.bx--number--light) .bx--number__control-btn::before,
+  .bx--number:not(.bx--number--light) .bx--number__control-btn::after,
+  .bx--text-input:not(.bx--text-input--light),
+  .bx--select-input {
+    background-color: $field-01;
+  }
 </style>


### PR DESCRIPTION
Refs: https://github.com/carbon-design-system/carbon/issues/8286

In `carbon-components` v10.32, input styles have a default value of $field-02. This is a hotfix that patches the documentation site styles to reset the value to $field-01.

I will patch the release as well.