### PR TITLE
Fix "Cannot use import statement outside a module"

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -93,7 +93,7 @@
 
   import { createEventDispatcher, setContext } from "svelte";
   import { writable, derived } from "svelte/store";
-  import ChevronRight16 from "carbon-icons-svelte/lib/ChevronRight16";
+  import ChevronRight16 from "carbon-icons-svelte/lib/ChevronRight16/ChevronRight16.svelte";
   import { InlineCheckbox } from "../Checkbox";
   import { RadioButton } from "../RadioButton";
   import Table from "./Table.svelte";

--- a/src/UIShell/SideNav/HamburgerMenu.svelte
+++ b/src/UIShell/SideNav/HamburgerMenu.svelte
@@ -11,8 +11,8 @@
   /** Obtain a reference to the HTML button element */
   export let ref = null;
 
-  import Close20 from "carbon-icons-svelte/lib/Close20";
-  import Menu20 from "carbon-icons-svelte/lib/Menu20";
+  import Close20 from "carbon-icons-svelte/lib/Close20/Close20.svelte";
+  import Menu20 from "carbon-icons-svelte/lib/Menu20/Menu20.svelte";
   import { Icon } from "../../Icon";
 </script>
 


### PR DESCRIPTION
Using `HamburgerMenu` from a SvelteKit project would result in the following error:

```
4:01:51 PM [vite] Error when evaluating SSR module /node_modules/carbon-components-svelte/src/UIShell/SideNav/HamburgerMenu.svelte:
/home/vegard/beat/backoffice-sapper/node_modules/carbon-icons-svelte/lib/Close20/index.js:1
import Close20 from "./Close20.svelte";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at wrapSafe (internal/modules/cjs/loader.js:1101:16)
    at Module._compile (internal/modules/cjs/loader.js:1149:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1205:10)
    at Module.load (internal/modules/cjs/loader.js:1034:32)
    at Function.Module._load (internal/modules/cjs/loader.js:923:14)
    at Module.require (internal/modules/cjs/loader.js:1074:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at nodeRequire (/home/vegard/beat/backoffice-sapper/node_modules/vite/dist/node/chunks/dep-66eb515d.js:69044:17)
    at ssrImport (/home/vegard/beat/backoffice-sapper/node_modules/vite/dist/node/chunks/dep-66eb515d.js:69002:20)
    at eval (/node_modules/carbon-components-svelte/src/UIShell/SideNav/HamburgerMenu.svelte:7:31) (x3)
```

To fix it, we need to reference the `.svelte` files for the icons.