### PR TITLE
fix dropdown keyboard usage

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -203,7 +203,11 @@
       tabindex="0"
       role="button"
       aria-expanded="{open}"
-      on:keydown="{({ key }) => {
+      on:keydown="{(e) => {
+        const { key } = e;
+        if (['Enter', 'ArrowDown', 'ArrowUp'].includes(key)) {
+          e.preventDefault();
+        }
         if (key === 'Enter') {
           open = !open;
           if (highlightedIndex > -1 && highlightedIndex !== selectedIndex) {


### PR DESCRIPTION
Fixes can't open a dropdown with keyboard #607 
I didn't use the preventDefault modifier because it would also prevent the default of the tab. Which interferes with the tab navigation. 

While on this I found another inconsistency with other implementations. The selected options of a dropdown can be switch by arrow down and arrow up when the dropdown isn't opened. Other implementations like the vue and react version would open the Dropdown and switch highlighted options. Should I open another PR for it? Or I can just do it here.