### PR TITLE
fix(Dropdown): update selectedId when selectedIndex changes.

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -128,6 +128,7 @@
   }
   $: inline = type === "inline";
   $: selectedItem = items[selectedIndex];
+  $: selectedId = items[selectedIndex] ? items[selectedIndex].id : undefined;  
   $: if (!open) {
     highlightedIndex = -1;
   }


### PR DESCRIPTION
Hi guys!
Using the dropdown we found a visual bug. 
When we change the selectedIndex value from an external action like clicking a button, we can see the previously selected item active when we open the dropdown.

Here's a Minimal, Reproducible Example: [https://svelte.dev/repl/159395c52c3140f996616b57d74861f4?version=3.37.0](https://svelte.dev/repl/159395c52c3140f996616b57d74861f4?version=3.37.0)

Just wait for it to compile then:
Click the dropdown.
Click the third item.
Click the button that changes the selectedIndex.
Click the dropdown.

You will see the 2nd AND 3rd item active!
You should only see the 2nd 😅
This PR updates the internal selectedId variable when a valid selectedIndex is passed, otherwise, it sets it to undefined (its initialization value).