### PR TITLE
Fix TableCell "colspan" when a DataTable is Expandable and Selectable

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -410,7 +410,7 @@
               parentRowId = null;
             }}"
           >
-            <TableCell colspan="{headers.length + 1}">
+            <TableCell colspan="{selectable ? headers.length + 2 : headers.length + 1}">
               <div class:bx--child-row-inner-container="{true}">
                 <slot name="expanded-row" row="{row}" />
               </div>


### PR DESCRIPTION
Small fix to correct the width of the `expanded-row` slot when a DataTable is both expandable and selectable.

The `colspan` of TableCell that wraps the `expanded-row` slot is now set to `header.length + 2` instead of `header.length + 1` to accommodate the additional selectable column.