### PR TITLE
Add html input attributes to ToolbarSearchProps

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -11016,7 +11016,7 @@
         { "type": "forwarded", "name": "blur", "element": "Search" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "Search" }
+      "rest_props": { "type": "Element", "name": "input" }
     },
     {
       "moduleName": "Tooltip",

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -1,4 +1,6 @@
 <script>
+  /** @restProps {input} */
+
   /**
    * Specify the value of the search input
    * @type {number | string}

--- a/types/DataTable/ToolbarSearch.d.ts
+++ b/types/DataTable/ToolbarSearch.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface ToolbarSearchProps {
+export interface ToolbarSearchProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
   /**
    * Specify the value of the search input
    * @default ""


### PR DESCRIPTION
Fixes #646

ToolbarSearchProps are missing type definitions for $$restProops. With this PR `svelte-check` no longer complains and editors can show propose code completions. E.g. VS Code:

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/988276/118273881-c3699b80-b4c4-11eb-86f9-f122b9778cfc.png">

*Limitations*

This is just a very specific case. The proper definition of `$$restProps` in other components is subject to further work.
As an alternative to `svelte.JSX.HTMLAttributes` I would like to suggest [`Partial`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype) in a separate PR.