### PR TITLE
Add html input props to ToolbarSearchProps using Partial

### DIFF
--- a/types/DataTable/ToolbarSearch.d.ts
+++ b/types/DataTable/ToolbarSearch.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface ToolbarSearchProps {
+export interface ToolbarSearchProps extends Partial<HTMLElementTagNameMap["input"]> {
   /**
    * Specify the value of the search input
    * @default ""


### PR DESCRIPTION
Fixes #646
See also #647

ToolbarSearchProps are missing type definitions for $$restProops. With this PR `svelte-check` no longer complains and editors can show propose code completions. E.g. VS Code:

<img width="1226" alt="image" src="https://user-images.githubusercontent.com/988276/118274825-e9437000-b4c5-11eb-90e5-be01ce2ed973.png">

*Limitations*

This is just a very specific case. The proper definition of `$$restProps` in other components is subject to further work.
I’m not fully aware of what’s better `svelte.JSX.HTMLAttributes` (see #647) or  [`Partial`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype) such as used in this PR.