### PR TITLE
Align v10.36

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1663,12 +1663,12 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                       | Default value     | Description                                   |
-| :--------- | :--------------- | :------- | :----------------------------------------- | ----------------- | --------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code> | Obtain a reference to the HTML anchor element |
-| href       | <code>let</code> | No       | <code>string</code>                        | --                | Specify the `href` attribute                  |
-| text       | <code>let</code> | No       | <code>string</code>                        | --                | Specify the text                              |
-| isSelected | <code>let</code> | No       | --                                         | --                | Set to `true` to select the item              |
+| Prop name  | Kind             | Reactive | Type                                       | Default value      | Description                                   |
+| :--------- | :--------------- | :------- | :----------------------------------------- | ------------------ | --------------------------------------------- |
+| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>  | Obtain a reference to the HTML anchor element |
+| href       | <code>let</code> | No       | <code>string</code>                        | --                 | Specify the `href` attribute                  |
+| text       | <code>let</code> | No       | <code>string</code>                        | --                 | Specify the text                              |
+| isSelected | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code> | Set to `true` to select the item              |
 
 ### Slots
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1058,7 +1058,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -1254,7 +1256,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -1283,7 +1287,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -2765,7 +2771,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -2906,7 +2914,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -3046,7 +3056,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -3113,9 +3125,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| --        | Yes     | --    | --                       |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -3429,7 +3442,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -3971,7 +3986,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -4036,7 +4053,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -4143,9 +4162,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| --        | Yes     | --    | --                       |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -4179,9 +4199,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| --        | Yes     | --    | --                       |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -4241,7 +4262,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 
@@ -4269,7 +4292,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -650,6 +650,7 @@ None.
 | :--------- | :--------- | :------------------------------------------------------------------------------------- |
 | select     | dispatched | <code>{ selectedId: string; selectedIndex: number; selectedItem: ComboBoxItem }</code> |
 | keydown    | forwarded  | --                                                                                     |
+| keyup      | forwarded  | --                                                                                     |
 | focus      | forwarded  | --                                                                                     |
 | blur       | forwarded  | --                                                                                     |
 | clear      | forwarded  | --                                                                                     |
@@ -1063,6 +1064,7 @@ None.
 | :--------- | :-------- | :----- |
 | input      | forwarded | --     |
 | keydown    | forwarded | --     |
+| keyup      | forwarded | --     |
 | blur       | forwarded | --     |
 
 ## `DatePickerSkeleton`
@@ -2377,6 +2379,7 @@ None.
 | select     | dispatched | <code>{ selectedIds: string[]; selected: MultiSelectItem[]; unselected: MultiSelectItem[]; }</code> |
 | clear      | dispatched | <code>any</code>                                                                                    |
 | keydown    | forwarded  | --                                                                                                  |
+| keyup      | forwarded  | --                                                                                                  |
 | focus      | forwarded  | --                                                                                                  |
 | blur       | forwarded  | --                                                                                                  |
 
@@ -2773,6 +2776,7 @@ None.
 | change     | forwarded | --     |
 | input      | forwarded | --     |
 | keydown    | forwarded | --     |
+| keyup      | forwarded | --     |
 | focus      | forwarded | --     |
 | blur       | forwarded | --     |
 
@@ -3057,6 +3061,7 @@ None.
 | focus      | forwarded  | --               |
 | blur       | forwarded  | --               |
 | keydown    | forwarded  | --               |
+| keyup      | forwarded  | --               |
 | clear      | dispatched | --               |
 
 ## `SearchSkeleton`
@@ -3976,6 +3981,8 @@ None.
 | mouseleave | forwarded | --     |
 | change     | forwarded | --     |
 | input      | forwarded | --     |
+| keydown    | forwarded | --     |
+| keyup      | forwarded | --     |
 | focus      | forwarded | --     |
 | blur       | forwarded | --     |
 
@@ -4040,6 +4047,7 @@ None.
 | change     | forwarded | --     |
 | input      | forwarded | --     |
 | keydown    | forwarded | --     |
+| keyup      | forwarded | --     |
 | focus      | forwarded | --     |
 | blur       | forwarded | --     |
 
@@ -4147,6 +4155,8 @@ None.
 | mouseleave | forwarded | --     |
 | change     | forwarded | --     |
 | input      | forwarded | --     |
+| keydown    | forwarded | --     |
+| keyup      | forwarded | --     |
 | focus      | forwarded | --     |
 | blur       | forwarded | --     |
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1653,11 +1653,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value     | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ----------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code> | Obtain a reference to the HTML anchor element |
-| href      | <code>let</code> | No       | <code>string</code>                        | --                | Specify the `href` attribute                  |
-| text      | <code>let</code> | No       | <code>string</code>                        | --                | Specify the text                              |
+| Prop name  | Kind             | Reactive | Type                                       | Default value     | Description                                   |
+| :--------- | :--------------- | :------- | :----------------------------------------- | ----------------- | --------------------------------------------- |
+| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code> | Obtain a reference to the HTML anchor element |
+| href       | <code>let</code> | No       | <code>string</code>                        | --                | Specify the `href` attribute                  |
+| text       | <code>let</code> | No       | <code>string</code>                        | --                | Specify the text                              |
+| isSelected | <code>let</code> | No       | --                                         | --                | Set to `true` to select the item              |
 
 ### Slots
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3313,12 +3313,12 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                       | Default value     | Description                                   |
-| :--------- | :--------------- | :------- | :----------------------------------------- | ----------------- | --------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code> | Obtain a reference to the HTML anchor element |
-| isSelected | <code>let</code> | No       | <code>boolean</code>                       | --                | Set to `true` to select the item              |
-| href       | <code>let</code> | No       | <code>string</code>                        | --                | Specify the `href` attribute                  |
-| text       | <code>let</code> | No       | <code>string</code>                        | --                | Specify the item text                         |
+| Prop name  | Kind             | Reactive | Type                                       | Default value      | Description                                   |
+| :--------- | :--------------- | :------- | :----------------------------------------- | ------------------ | --------------------------------------------- |
+| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>  | Obtain a reference to the HTML anchor element |
+| isSelected | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code> | Set to `true` to select the item              |
+| href       | <code>let</code> | No       | <code>string</code>                        | --                 | Specify the `href` attribute                  |
+| text       | <code>let</code> | No       | <code>string</code>                        | --                 | Specify the item text                         |
 
 ### Slots
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3461,6 +3461,8 @@ None.
 | :-------- | :--------------- | :------- | :------------------- | ------------------ | ---------------------------------------------- |
 | selected  | <code>let</code> | Yes      | <code>string</code>  | --                 | Specify the selected structured list row value |
 | border    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the bordered variant      |
+| condensed | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant     |
+| flush     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to flush the list                |
 | selection | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the selection variant     |
 
 ### Slots

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -440,7 +440,9 @@ None.
 
 ### Slots
 
-None.
+| Slot name | Default | Props | Fallback                 |
+| :-------- | :------ | :---- | :----------------------- |
+| labelText | No      | --    | <code>{labelText}</code> |
 
 ### Events
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3216,6 +3216,7 @@ None.
 | :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------------ |
 | isOpen    | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code> | Set to `true` to toggle the expanded state |
 | fixed     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the fixed variant     |
+| rail      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the rail variant      |
 | ariaLabel | <code>let</code> | No       | <code>string</code>  | --                 | Specify the ARIA label for the nav         |
 
 ### Slots

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Carbon Svelte portfolio also includes:
 
 - **[Carbon Icons Svelte](https://github.com/IBM/carbon-icons-svelte)**: 6000+ Carbon icons as Svelte components
 - **[Carbon Pictograms Svelte](https://github.com/IBM/carbon-pictograms-svelte)**: 700+ Carbon pictograms as Svelte components
-- **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 17 chart types, powered by d3
+- **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 20 chart types, powered by d3
 
 ## [Documentation](http://ibm.biz/carbon-svelte)
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sveltech/routify": "^1.9.9",
     "autoprefixer": "^10.2.3",
-    "carbon-components": "10.35.0",
+    "carbon-components": "10.36.0",
     "carbon-components-svelte": "../",
     "mdsvex": "^0.8.8",
     "npm-run-all": "^4.1.5",

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4112,6 +4112,8 @@
           "name": "isSelected",
           "kind": "let",
           "description": "Set to `true` to select the item",
+          "type": "boolean",
+          "value": "false",
           "isFunction": false,
           "constant": false,
           "reactive": false

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8478,6 +8478,16 @@
           "reactive": false
         },
         {
+          "name": "rail",
+          "kind": "let",
+          "description": "Set to `true` to use the rail variant",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "ariaLabel",
           "kind": "let",
           "description": "Specify the ARIA label for the nav",

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1410,6 +1410,7 @@
           "detail": "{ selectedId: string; selectedIndex: number; selectedItem: ComboBoxItem }"
         },
         { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" },
         { "type": "forwarded", "name": "clear", "element": "ListBoxSelection" },
@@ -2526,6 +2527,7 @@
       "events": [
         { "type": "forwarded", "name": "input", "element": "input" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
@@ -5884,6 +5886,7 @@
         },
         { "type": "dispatched", "name": "clear", "detail": "any" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
@@ -7175,6 +7178,7 @@
         { "type": "forwarded", "name": "change", "element": "input" },
         { "type": "forwarded", "name": "input", "element": "input" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
@@ -8042,6 +8046,7 @@
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "dispatched", "name": "clear" }
       ],
       "typedefs": [],
@@ -10064,6 +10069,8 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" },
         { "type": "forwarded", "name": "change", "element": "textarea" },
         { "type": "forwarded", "name": "input", "element": "textarea" },
+        { "type": "forwarded", "name": "keydown", "element": "textarea" },
+        { "type": "forwarded", "name": "keyup", "element": "textarea" },
         { "type": "forwarded", "name": "focus", "element": "textarea" },
         { "type": "forwarded", "name": "blur", "element": "textarea" }
       ],
@@ -10287,6 +10294,7 @@
         { "type": "forwarded", "name": "change", "element": "input" },
         { "type": "forwarded", "name": "input", "element": "input" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
@@ -10543,6 +10551,8 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" },
         { "type": "forwarded", "name": "change", "element": "input" },
         { "type": "forwarded", "name": "input", "element": "input" },
+        { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8655,6 +8655,7 @@
           "kind": "let",
           "description": "Set to `true` to select the item",
           "type": "boolean",
+          "value": "false",
           "isFunction": false,
           "constant": false,
           "reactive": false

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -715,7 +715,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "dispatched", "name": "check", "detail": "boolean" },
         { "type": "forwarded", "name": "click", "element": "CheckboxSkeleton" },

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2530,7 +2530,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "input", "element": "input" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
@@ -3225,7 +3232,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "keydown", "element": "label" },
         { "type": "forwarded", "name": "change", "element": "input" },
@@ -3339,7 +3353,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "dispatched", "name": "add", "detail": "FileList" },
         { "type": "forwarded", "name": "dragover", "element": "div" },
@@ -7176,7 +7197,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -7561,7 +7589,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [{ "type": "forwarded", "name": "change", "element": "input" }],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }
@@ -8028,7 +8063,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "dispatched", "name": "expand", "detail": "any" },
         { "type": "dispatched", "name": "collapse", "detail": "any" },
@@ -8255,7 +8297,15 @@
           "reactive": true
         }
       ],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "dispatched", "name": "change", "detail": "string" },
         { "type": "forwarded", "name": "blur", "element": "select" }
@@ -8994,7 +9044,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -10068,7 +10125,14 @@
           "reactive": true
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -10292,7 +10356,14 @@
           "reactive": false
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -10550,7 +10621,15 @@
           "reactive": true
         }
       ],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -10649,7 +10728,15 @@
           "reactive": true
         }
       ],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
@@ -10853,7 +10940,14 @@
           "reactive": false
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         {
           "type": "dispatched",
@@ -10907,7 +11001,14 @@
           "reactive": false
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "labelText",
+          "default": false,
+          "fallback": "{labelText}",
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4079,6 +4079,14 @@
           "reactive": false
         },
         {
+          "name": "isSelected",
+          "kind": "let",
+          "description": "Set to `true` to select the item",
+          "isFunction": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "ref",
           "kind": "let",
           "description": "Obtain a reference to the HTML anchor element",

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -9023,6 +9023,26 @@
           "reactive": false
         },
         {
+          "name": "condensed",
+          "kind": "let",
+          "description": "Set to `true` to use the condensed variant",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "flush",
+          "kind": "let",
+          "description": "Set to `true` to flush the list",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "selection",
           "kind": "let",
           "description": "Set to `true` to use the selection variant",

--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -78,10 +78,10 @@
               {/if}
             </StructuredListCell>
             <StructuredListCell>
-              {#each prop.type.split(" | ") as type, i (type)}
+              {#each (prop.type || "").split(" | ") as type, i (type)}
                 <div
                   class="cell"
-                  style="z-index: {prop.type.split(' | ').length - i}"
+                  style="z-index: {(prop.type || '').split(' | ').length - i}"
                 >
                   {#if type.startsWith("typeof")}
                     <TooltipDefinition

--- a/docs/src/pages/components/StructuredList.svx
+++ b/docs/src/pages/components/StructuredList.svx
@@ -52,6 +52,94 @@ components: ["StructuredList", "StructuredListSkeleton", "StructuredListBody", "
   </StructuredListBody>
 </StructuredList>
 
+### Condensed variant
+
+<StructuredList condensed>
+  <StructuredListHead>
+    <StructuredListRow head>
+      <StructuredListCell head>Column A</StructuredListCell>
+      <StructuredListCell head>Column B</StructuredListCell>
+      <StructuredListCell head>Column C</StructuredListCell>
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    <StructuredListRow>
+      <StructuredListCell noWrap>Row 1</StructuredListCell>
+      <StructuredListCell>Row 1</StructuredListCell>
+      <StructuredListCell>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+        magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+        sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+        vulputate nisl a porttitor interdum.
+      </StructuredListCell>
+    </StructuredListRow>
+    <StructuredListRow>
+      <StructuredListCell noWrap>Row 2</StructuredListCell>
+      <StructuredListCell>Row 2</StructuredListCell>
+      <StructuredListCell>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+        magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+        sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+        vulputate nisl a porttitor interdum.
+      </StructuredListCell>
+    </StructuredListRow>
+    <StructuredListRow>
+      <StructuredListCell noWrap>Row 3</StructuredListCell>
+      <StructuredListCell>Row 3</StructuredListCell>
+      <StructuredListCell>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+        magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+        sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+        vulputate nisl a porttitor interdum.
+      </StructuredListCell>
+    </StructuredListRow>
+  </StructuredListBody>
+</StructuredList>
+
+### Flush
+
+<StructuredList flush>
+  <StructuredListHead>
+    <StructuredListRow head>
+      <StructuredListCell head>Column A</StructuredListCell>
+      <StructuredListCell head>Column B</StructuredListCell>
+      <StructuredListCell head>Column C</StructuredListCell>
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    <StructuredListRow>
+      <StructuredListCell noWrap>Row 1</StructuredListCell>
+      <StructuredListCell>Row 1</StructuredListCell>
+      <StructuredListCell>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+        magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+        sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+        vulputate nisl a porttitor interdum.
+      </StructuredListCell>
+    </StructuredListRow>
+    <StructuredListRow>
+      <StructuredListCell noWrap>Row 2</StructuredListCell>
+      <StructuredListCell>Row 2</StructuredListCell>
+      <StructuredListCell>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+        magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+        sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+        vulputate nisl a porttitor interdum.
+      </StructuredListCell>
+    </StructuredListRow>
+    <StructuredListRow>
+      <StructuredListCell noWrap>Row 3</StructuredListCell>
+      <StructuredListCell>Row 3</StructuredListCell>
+      <StructuredListCell>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+        magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+        sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+        vulputate nisl a porttitor interdum.
+      </StructuredListCell>
+    </StructuredListRow>
+  </StructuredListBody>
+</StructuredList>
+
 ### Selectable rows
 
 <StructuredList selection selected="row-1-value">

--- a/docs/src/pages/components/Tag.svx
+++ b/docs/src/pages/components/Tag.svx
@@ -49,6 +49,12 @@ Note: rendering a custom icon cannnot be used with the filterable variant.
 Set `interactive` to `true` to render a `button` element instead of a `div`.
 
 <Tag interactive>Machine learning</Tag>
+
+### Disabled
+
+The filterable and interactive tag variants have a disabled state.
+
+<Tag filter disabled>Machine learning</Tag>
 <Tag interactive disabled>Machine learning</Tag>
 
 ### Skeleton

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -40,7 +40,7 @@ The hamburger menu will automatically be rendered if the `SideNav` component is 
 
 Set `rail` to `true` on `SideNav` to use the rail variant.
 
-<FileSource src="/framed/UIShell/HeaderNav" />
+<FileSource src="/framed/UIShell/HeaderNavRail" />
 
 ### Header with app switcher
 

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -36,6 +36,12 @@ The hamburger menu will automatically be rendered if the `SideNav` component is 
 
 <FileSource src="/framed/UIShell/HeaderNav" />
 
+### Header with side navigation (rail)
+
+Set `rail` to `true` on `SideNav` to use the rail variant.
+
+<FileSource src="/framed/UIShell/HeaderNav" />
+
 ### Header with app switcher
 
 The `HeaderAction` component uses the [transition:slide API](https://svelte.dev/docs#slide); you can customize the transition duration, delay, and easing with the `transition` prop.

--- a/docs/src/pages/framed/UIShell/HeaderNavRail.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNavRail.svelte
@@ -1,0 +1,65 @@
+<script>
+  import {
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    HeaderNavMenu,
+    SideNav,
+    SideNavItems,
+    SideNavMenu,
+    SideNavMenuItem,
+    SideNavLink,
+    SideNavDivider,
+    SkipToContent,
+    Content,
+    Grid,
+    Row,
+    Column,
+  } from "carbon-components-svelte";
+  import Fade16 from "carbon-icons-svelte/lib/Fade16";
+
+  let isSideNavOpen = false;
+</script>
+
+<Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
+  <div slot="skip-to-content">
+    <SkipToContent />
+  </div>
+
+  <HeaderNav>
+    <HeaderNavItem href="/" text="Link 1" />
+    <HeaderNavItem href="/" text="Link 2" />
+    <HeaderNavItem href="/" text="Link 3" />
+    <HeaderNavMenu text="Menu">
+      <HeaderNavItem href="/" text="Link 1" />
+      <HeaderNavItem href="/" text="Link 2" />
+      <HeaderNavItem href="/" text="Link 3" />
+    </HeaderNavMenu>
+    <HeaderNavItem href="/" text="Link 4" />
+  </HeaderNav>
+</Header>
+
+<SideNav bind:isOpen="{isSideNavOpen}" rail>
+  <SideNavItems>
+    <SideNavLink icon="{Fade16}" text="Link 1" href="/" isSelected />
+    <SideNavLink icon="{Fade16}" text="Link 2" href="/" />
+    <SideNavLink icon="{Fade16}" text="Link 3" href="/" />
+    <SideNavMenu icon="{Fade16}" text="Menu">
+      <SideNavMenuItem href="/" text="Link 1" />
+      <SideNavMenuItem href="/" text="Link 2" />
+      <SideNavMenuItem href="/" text="Link 3" />
+    </SideNavMenu>
+    <SideNavDivider />
+    <SideNavLink icon="{Fade16}" text="Link 4" href="/" />
+  </SideNavItems>
+</SideNav>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <h1>Welcome</h1>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -100,7 +100,7 @@
       <Column xlg="{5}" lg="{8}" md="{4}">
         <TileCard
           title="Carbon Charts Svelte"
-          subtitle="17 chart types, powered by d3"
+          subtitle="20 chart types, powered by d3"
           target="_blank"
           href="https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte"
         />

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -837,16 +837,16 @@ caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001178:
   integrity sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==
 
 carbon-components-svelte@../:
-  version "0.34.0"
+  version "0.35.0"
   dependencies:
     carbon-icons-svelte "^10.27.0"
     clipboard-copy "3.2.0"
     flatpickr "4.6.9"
 
-carbon-components@10.35.0:
-  version "10.35.0"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.35.0.tgz#2669d8f6f989a5dc96843c43a5ac12e4a9c3dfa7"
-  integrity sha512-1njVUjaN/+gVd5WkHPW4EkmweZvpsWOaUP2FgRglxLQNtRXbi902HJYsl9mufV3Op/oGvN4rSdtttxgYCf8YFg==
+carbon-components@10.36.0:
+  version "10.36.0"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.36.0.tgz#ce523b19df3a404e379113dafbbe0219bb22b17f"
+  integrity sha512-k+UR+Whz/qXbev2RT9JjV+QbkSKcHrLNF25bEpr3KZHmpCGhwGz5mVyv0ohZ4B6rKkpuvlgYfLsANL0yQX77zA==
   dependencies:
     "@carbon/telemetry" "0.0.0-alpha.6"
     flatpickr "4.6.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@rollup/plugin-node-resolve": "^11.1.1",
     "@tsconfig/svelte": "^1.0.10",
     "autoprefixer": "^10.2.4",
-    "carbon-components": "10.35.0",
+    "carbon-components": "10.36.0",
     "gh-pages": "^3.1.0",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.3",

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -85,7 +85,9 @@
         class:bx--checkbox-label-text="{true}"
         class:bx--visually-hidden="{hideLabel}"
       >
-        {labelText}
+        <slot name="labelText">
+          {labelText}
+        </slot>
       </span>
     </label>
   </div>

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -97,6 +97,8 @@
   }
 
   $: expandText = expanded ? showLessText : showMoreText;
+  $: minHeight = expanded ? 16 * 15 : 48;
+  $: maxHeight = expanded ? "none" : 16 * 15 + "px";
   $: if (type === "multi" && ref) {
     if (code === undefined) setShowMoreLess();
     if (code) tick().then(setShowMoreLess);
@@ -178,6 +180,7 @@
       tabindex="{type === 'single' && !disabled ? '0' : undefined}"
       aria-label="{$$restProps['aria-label'] || copyLabel || 'code-snippet'}"
       class:bx--snippet-container="{true}"
+      style="width: 100%; min-height: {minHeight}px; max-height: {maxHeight}"
     >
       <pre
         bind:this="{ref}">

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -238,6 +238,7 @@
             open = false;
           }
         }}"
+        on:keyup
         on:focus
         on:blur
         on:blur="{({ relatedTarget }) => {

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -85,7 +85,9 @@
       class:bx--visually-hidden="{hideLabel}"
       class:bx--label--disabled="{disabled}"
     >
-      {labelText}
+      <slot name="labelText">
+        {labelText}
+      </slot>
     </label>
   {/if}
   <div

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -120,6 +120,7 @@
           focusCalendar();
         }
       }}"
+      on:keyup
       on:blur
       on:blur="{({ relatedTarget }) => {
         blurInput(relatedTarget);

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -54,7 +54,11 @@
     }
   }}"
 >
-  <span role="{role}">{labelText}</span>
+  <span role="{role}">
+    <slot name="labelText">
+      {labelText}
+    </slot>
+  </span>
 </label>
 <input
   bind:this="{ref}"

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -89,7 +89,9 @@
       class:bx--file__drop-container="{true}"
       class:bx--file__drop-container--drag-over="{over}"
     >
-      {labelText}
+      <slot name="labelText">
+        {labelText}
+      </slot>
       <input
         bind:this="{ref}"
         type="file"

--- a/src/ImageLoader/ImageLoader.svelte
+++ b/src/ImageLoader/ImageLoader.svelte
@@ -67,7 +67,7 @@
   let image = null;
 
   $: loading = !loaded && !error;
-  $: if (src) loadImage();
+  $: if (src && typeof window !== "undefined") loadImage();
   $: if (loaded) dispatch("load");
   $: if (error) dispatch("error");
 

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -382,6 +382,7 @@
               change(-1);
             }
           }}"
+          on:keyup
           on:focus
           on:blur
           on:blur="{({ relatedTarget }) => {

--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -68,7 +68,11 @@
   <label class:bx--radio-button__label="{true}" for="{id}">
     <span class:bx--radio-button__appearance="{true}"></span>
     {#if labelText}
-      <span class:bx--visually-hidden="{hideLabel}">{labelText}</span>
+      <span class:bx--visually-hidden="{hideLabel}">
+        <slot name="labelText">
+          {labelText}
+        </slot>
+      </span>
     {/if}
   </label>
 </div>

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -155,6 +155,7 @@
           dispatch('clear');
         }
       }}"
+      on:keyup
     />
     <button
       type="button"

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -117,9 +117,11 @@
     >
       <svelte:component this="{icon}" class="bx--search-magnifier-icon" />
     </div>
-    <label id="{id}-search" for="{id}" class:bx--label="{true}"
-      >{labelText}</label
-    >
+    <label id="{id}-search" for="{id}" class:bx--label="{true}">
+      <slot name="labelText">
+        {labelText}
+      </slot>
+    </label>
     <!-- svelte-ignore a11y-autofocus -->
     <input
       bind:this="{ref}"

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -96,7 +96,9 @@
         class:bx--visually-hidden="{hideLabel}"
         class:bx--label--disabled="{disabled}"
       >
-        {labelText}
+        <slot name="labelText">
+          {labelText}
+        </slot>
       </label>
     {/if}
     {#if inline}

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -137,7 +137,9 @@
     class:bx--label="{true}"
     class:bx--label--disabled="{disabled}"
   >
-    {labelText}
+    <slot name="labelText">
+      {labelText}
+    </slot>
   </label>
   <div class:bx--slider-container="{true}">
     <span class:bx--slider__range-label="{true}">{minLabel || min}</span>

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -8,6 +8,12 @@
   /** Set to `true` to use the bordered variant */
   export let border = false;
 
+  /** Set to `true` to use the condensed variant */
+  export let condensed = false;
+
+  /** Set to `true` to flush the list */
+  export let flush = false;
+
   /** Set to `true` to use the selection variant */
   export let selection = false;
 
@@ -33,6 +39,8 @@
   class:bx--structured-list="{true}"
   class:bx--structured-list--border="{border}"
   class:bx--structured-list--selection="{selection}"
+  class:bx--structured-list--condensed="{condensed}"
+  class:bx--structured-list--flush="{flush}"
   {...$$restProps}
   on:click
   on:mouseover

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -5,7 +5,10 @@
    */
   export let selected = undefined;
 
-  /** Set to `true` to use the bordered variant */
+  /**
+   * Set to `true` to use the bordered variant
+   * @deprecated
+   */
   export let border = false;
 
   /** Set to `true` to use the condensed variant */

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -93,6 +93,8 @@
       on:input="{({ target }) => {
         value = target.value;
       }}"
+      on:keydown
+      on:keyup
       on:focus
       on:blur></textarea>
   </div>

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -63,7 +63,9 @@
       class:bx--visually-hidden="{hideLabel}"
       class:bx--label--disabled="{disabled}"
     >
-      {labelText}
+      <slot name="labelText">
+        {labelText}
+      </slot>
     </label>
   {/if}
   <div

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -180,6 +180,7 @@
           value = target.value;
         }}"
         on:keydown
+        on:keyup
         on:focus
         on:blur
       />

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -114,7 +114,9 @@
       class:bx--label--inline--sm="{inline && size === 'sm'}"
       class:bx--label--inline--xl="{inline && size === 'xl'}"
     >
-      {labelText}
+      <slot name="labelText">
+        {labelText}
+      </slot>
     </label>
     {#if !isFluid && helperText}
       <div
@@ -135,7 +137,9 @@
       class:bx--label--inline--sm="{inline && size === 'sm'}"
       class:bx--label--inline--xl="{inline && size === 'xl'}"
     >
-      {labelText}
+      <slot name="labelText">
+        {labelText}
+      </slot>
     </label>
   {/if}
   <div

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -93,7 +93,9 @@
           class:bx--label--inline="{inline}"
           class="{inline && !!size && `bx--label--inline--${size}`}"
         >
-          {labelText}
+          <slot name="labelText">
+            {labelText}
+          </slot>
         </label>
       {/if}
       {#if !isFluid && helperText}
@@ -116,7 +118,9 @@
       class:bx--label--inline="{inline}"
       class="{inline && !!size && `bx--label--inline--${size}`}"
     >
-      {labelText}
+      <slot name="labelText">
+        {labelText}
+      </slot>
     </label>
   {/if}
   <div

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -163,6 +163,7 @@
           value = target.value;
         }}"
         on:keydown
+        on:keyup
         on:focus
         on:blur
       />

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -104,6 +104,8 @@
         on:input="{({ target }) => {
           value = target.value;
         }}"
+        on:keydown
+        on:keyup
         on:focus
         on:blur
       />

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -80,7 +80,9 @@
           class:bx--visually-hidden="{hideLabel}"
           class:bx--label--disabled="{disabled}"
         >
-          {labelText}
+          <slot name="labelText">
+            {labelText}
+          </slot>
         </label>
       {/if}
       <input

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -60,7 +60,9 @@
       class:bx--visually-hidden="{hideLabel}"
     >
       <!-- TODO: set to always be `true` after `hideLabel` is deprecated -->
-      {labelText}
+      <slot name="labelText">
+        {labelText}
+      </slot>
     </label>
   {/if}
   <!-- svelte-ignore a11y-no-onchange -->

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -75,7 +75,9 @@
     for="{id}"
     class:bx--toggle-input__label="{true}"
   >
-    {labelText}
+    <slot name="labelText">
+      {labelText}
+    </slot>
     <span class:bx--toggle__switch="{true}">
       <span aria-hidden="true" class:bx--toggle__text--off="{true}">
         {labelA}

--- a/src/Toggle/ToggleSkeleton.svelte
+++ b/src/Toggle/ToggleSkeleton.svelte
@@ -36,7 +36,11 @@
     class:bx--skeleton="{true}"
   >
     {#if labelText}
-      <span class:bx--toggle__label-text="{true}">{labelText}</span>
+      <span class:bx--toggle__label-text="{true}">
+        <slot name="labelText">
+          {labelText}
+        </slot>
+      </span>
     {/if}
     <span class:bx--toggle__text--left="{true}"></span>
     <span class:bx--toggle__appearance="{true}"></span>

--- a/src/UIShell/GlobalHeader/HeaderNavItem.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNavItem.svelte
@@ -12,7 +12,7 @@
   export let text = undefined;
 
   /** Set to `true` to select the item */
-  export let isSelected = undefined;
+  export let isSelected = false;
 
   /** Obtain a reference to the HTML anchor element */
   export let ref = null;

--- a/src/UIShell/GlobalHeader/HeaderNavItem.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNavItem.svelte
@@ -11,6 +11,9 @@
    */
   export let text = undefined;
 
+  /** Set to `true` to select the item */
+  export let isSelected = undefined;
+
   /** Obtain a reference to the HTML anchor element */
   export let ref = null;
 </script>
@@ -23,6 +26,7 @@
     href="{href}"
     rel="{$$restProps.target === '_blank' ? 'noopener noreferrer' : undefined}"
     class:bx--header__menu-item="{true}"
+    aria-current="{isSelected ? 'page' : undefined}"
     {...$$restProps}
     on:click
     on:mouseover

--- a/src/UIShell/SideNav/SideNav.svelte
+++ b/src/UIShell/SideNav/SideNav.svelte
@@ -8,6 +8,9 @@
   /** Set to `true` to use the fixed variant */
   export let fixed = false;
 
+  /** Set to `true` to use the rail variant */
+  export let rail = false;
+
   /**
    * Specify the ARIA label for the nav
    * @type {string}
@@ -46,8 +49,9 @@
   class:bx--side-nav__navigation="{true}"
   class:bx--side-nav="{true}"
   class:bx--side-nav--ux="{true}"
-  class:bx--side-nav--expanded="{isOpen}"
-  class:bx--side-nav--collapsed="{!isOpen}"
+  class:bx--side-nav--expanded="{isOpen && !rail}"
+  class:bx--side-nav--collapsed="{!isOpen && !rail}"
+  class:bx--side-nav--rail="{rail}"
   {...$$restProps}
 >
   <slot />

--- a/src/UIShell/SideNav/SideNavMenuItem.svelte
+++ b/src/UIShell/SideNav/SideNavMenuItem.svelte
@@ -1,9 +1,6 @@
 <script>
-  /**
-   * Set to `true` to select the item
-   * @type {boolean}
-   */
-  export let isSelected = undefined;
+  /** Set to `true` to select the item */
+  export let isSelected = false;
 
   /**
    * Specify the `href` attribute

--- a/types/Checkbox/Checkbox.d.ts
+++ b/types/Checkbox/Checkbox.d.ts
@@ -78,5 +78,5 @@ export default class Checkbox extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: WindowEventMap["change"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/ComboBox/ComboBox.d.ts
+++ b/types/ComboBox/ComboBox.d.ts
@@ -147,6 +147,7 @@ export default class ComboBox extends SvelteComponentTyped<
       selectedItem: ComboBoxItem;
     }>;
     keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
     clear: WindowEventMap["clear"];

--- a/types/DatePicker/DatePickerInput.d.ts
+++ b/types/DatePicker/DatePickerInput.d.ts
@@ -100,5 +100,5 @@ export default class DatePickerInput extends SvelteComponentTyped<
     keyup: WindowEventMap["keyup"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/DatePicker/DatePickerInput.d.ts
+++ b/types/DatePicker/DatePickerInput.d.ts
@@ -97,6 +97,7 @@ export default class DatePickerInput extends SvelteComponentTyped<
   {
     input: WindowEventMap["input"];
     keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     blur: WindowEventMap["blur"];
   },
   {}

--- a/types/FileUploader/FileUploaderButton.d.ts
+++ b/types/FileUploader/FileUploaderButton.d.ts
@@ -77,5 +77,5 @@ export default class FileUploaderButton extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     click: WindowEventMap["click"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/FileUploader/FileUploaderDropContainer.d.ts
+++ b/types/FileUploader/FileUploaderDropContainer.d.ts
@@ -76,5 +76,5 @@ export default class FileUploaderDropContainer extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     click: WindowEventMap["click"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/MultiSelect/MultiSelect.d.ts
+++ b/types/MultiSelect/MultiSelect.d.ts
@@ -192,6 +192,7 @@ export default class MultiSelect extends SvelteComponentTyped<
     }>;
     clear: CustomEvent<any>;
     keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },

--- a/types/RadioButton/RadioButton.d.ts
+++ b/types/RadioButton/RadioButton.d.ts
@@ -61,5 +61,5 @@ export interface RadioButtonProps
 export default class RadioButton extends SvelteComponentTyped<
   RadioButtonProps,
   { change: WindowEventMap["change"] },
-  {}
+  { labelText: {} }
 > {}

--- a/types/Search/Search.d.ts
+++ b/types/Search/Search.d.ts
@@ -126,5 +126,5 @@ export default class Search extends SvelteComponentTyped<
     keyup: WindowEventMap["keyup"];
     clear: CustomEvent<any>;
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/Search/Search.d.ts
+++ b/types/Search/Search.d.ts
@@ -123,6 +123,7 @@ export default class Search extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
     keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     clear: CustomEvent<any>;
   },
   {}

--- a/types/Select/Select.d.ts
+++ b/types/Select/Select.d.ts
@@ -100,5 +100,5 @@ export interface SelectProps
 export default class Select extends SvelteComponentTyped<
   SelectProps,
   { change: CustomEvent<string>; blur: WindowEventMap["blur"] },
-  { default: {} }
+  { default: {}; labelText: {} }
 > {}

--- a/types/Slider/Slider.d.ts
+++ b/types/Slider/Slider.d.ts
@@ -115,5 +115,5 @@ export default class Slider extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: CustomEvent<any>;
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/StructuredList/StructuredList.d.ts
+++ b/types/StructuredList/StructuredList.d.ts
@@ -15,6 +15,18 @@ export interface StructuredListProps
   border?: boolean;
 
   /**
+   * Set to `true` to use the condensed variant
+   * @default false
+   */
+  condensed?: boolean;
+
+  /**
+   * Set to `true` to flush the list
+   * @default false
+   */
+  flush?: boolean;
+
+  /**
    * Set to `true` to use the selection variant
    * @default false
    */

--- a/types/TextArea/TextArea.d.ts
+++ b/types/TextArea/TextArea.d.ts
@@ -96,6 +96,8 @@ export default class TextArea extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: WindowEventMap["change"];
     input: WindowEventMap["input"];
+    keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },

--- a/types/TextArea/TextArea.d.ts
+++ b/types/TextArea/TextArea.d.ts
@@ -101,5 +101,5 @@ export default class TextArea extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/TextInput/PasswordInput.d.ts
+++ b/types/TextInput/PasswordInput.d.ts
@@ -142,5 +142,5 @@ export default class PasswordInput extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/TextInput/PasswordInput.d.ts
+++ b/types/TextInput/PasswordInput.d.ts
@@ -138,6 +138,7 @@ export default class PasswordInput extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     input: WindowEventMap["input"];
     keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },

--- a/types/TextInput/TextInput.d.ts
+++ b/types/TextInput/TextInput.d.ts
@@ -120,6 +120,7 @@ export default class TextInput extends SvelteComponentTyped<
     change: WindowEventMap["change"];
     input: WindowEventMap["input"];
     keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },

--- a/types/TextInput/TextInput.d.ts
+++ b/types/TextInput/TextInput.d.ts
@@ -124,5 +124,5 @@ export default class TextInput extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/TimePicker/TimePicker.d.ts
+++ b/types/TimePicker/TimePicker.d.ts
@@ -101,6 +101,8 @@ export default class TimePicker extends SvelteComponentTyped<
     mouseleave: WindowEventMap["mouseleave"];
     change: WindowEventMap["change"];
     input: WindowEventMap["input"];
+    keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },

--- a/types/TimePicker/TimePicker.d.ts
+++ b/types/TimePicker/TimePicker.d.ts
@@ -106,5 +106,5 @@ export default class TimePicker extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  { default: {} }
+  { default: {}; labelText: {} }
 > {}

--- a/types/TimePicker/TimePickerSelect.d.ts
+++ b/types/TimePicker/TimePickerSelect.d.ts
@@ -58,5 +58,5 @@ export default class TimePickerSelect extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  { default: {} }
+  { default: {}; labelText: {} }
 > {}

--- a/types/Toggle/Toggle.d.ts
+++ b/types/Toggle/Toggle.d.ts
@@ -64,5 +64,5 @@ export default class Toggle extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/Toggle/ToggleSkeleton.d.ts
+++ b/types/Toggle/ToggleSkeleton.d.ts
@@ -30,5 +30,5 @@ export default class ToggleSkeleton extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
   },
-  {}
+  { labelText: {} }
 > {}

--- a/types/UIShell/GlobalHeader/HeaderNavItem.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderNavItem.d.ts
@@ -15,8 +15,9 @@ export interface HeaderNavItemProps
 
   /**
    * Set to `true` to select the item
+   * @default false
    */
-  isSelected?: undefined;
+  isSelected?: boolean;
 
   /**
    * Obtain a reference to the HTML anchor element

--- a/types/UIShell/GlobalHeader/HeaderNavItem.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderNavItem.d.ts
@@ -14,6 +14,11 @@ export interface HeaderNavItemProps
   text?: string;
 
   /**
+   * Set to `true` to select the item
+   */
+  isSelected?: undefined;
+
+  /**
    * Obtain a reference to the HTML anchor element
    * @default null
    */

--- a/types/UIShell/SideNav/SideNav.d.ts
+++ b/types/UIShell/SideNav/SideNav.d.ts
@@ -10,6 +10,12 @@ export interface SideNavProps
   fixed?: boolean;
 
   /**
+   * Set to `true` to use the rail variant
+   * @default false
+   */
+  rail?: boolean;
+
+  /**
    * Specify the ARIA label for the nav
    */
   ariaLabel?: string;

--- a/types/UIShell/SideNav/SideNavMenuItem.d.ts
+++ b/types/UIShell/SideNav/SideNavMenuItem.d.ts
@@ -5,6 +5,7 @@ export interface SideNavMenuItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
    * Set to `true` to select the item
+   * @default false
    */
   isSelected?: boolean;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,10 +453,10 @@ caniuse-lite@^1.0.30001181:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz#7a57ba9d6584119bb5f2bc76d3cc47ba9356b3e2"
   integrity sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==
 
-carbon-components@10.35.0:
-  version "10.35.0"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.35.0.tgz#2669d8f6f989a5dc96843c43a5ac12e4a9c3dfa7"
-  integrity sha512-1njVUjaN/+gVd5WkHPW4EkmweZvpsWOaUP2FgRglxLQNtRXbi902HJYsl9mufV3Op/oGvN4rSdtttxgYCf8YFg==
+carbon-components@10.36.0:
+  version "10.36.0"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.36.0.tgz#ce523b19df3a404e379113dafbbe0219bb22b17f"
+  integrity sha512-k+UR+Whz/qXbev2RT9JjV+QbkSKcHrLNF25bEpr3KZHmpCGhwGz5mVyv0ohZ4B6rKkpuvlgYfLsANL0yQX77zA==
   dependencies:
     "@carbon/telemetry" "0.0.0-alpha.6"
     flatpickr "4.6.1"


### PR DESCRIPTION
**Features**

- add condensed, flush props to `StructuredList`
- support `SideNav` rail, closes #601
- add isSelected prop to `HeaderNavItem`
- make components with `labelText` prop slottable (e.g., <span slot="labelText">...</span>)

**Fixes**

- set min/max height for multi-line `CodeSnippet`
- make `ImageLoader` SSR compatible by using a window type check guard
- default isSelected to false in `SideNavMenuItem`
- forward keydown event to `TextArea`
- deprecate border prop in `StructuredList`

**Documentation**

- add separate disabled example for filterable/interactive tags
- update number of supported chart types from 17 to 20

**Housekeeping**

- upgrade `carbon-components` to version 10.36.0