### PR TITLE
docs: add g80 to valid themes

### DIFF
--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -37,7 +37,7 @@
   onMount(() => {
     const currentTheme = window.location.search.split("?theme=")[1];
 
-    if (["white", "g10", "g90", "g100"].includes(currentTheme)) {
+    if (["white", "g10", "g80", "g90", "g100"].includes(currentTheme)) {
       theme.set(currentTheme);
     }
   });


### PR DESCRIPTION
This adds "g80" to the array of valid themes.

This allows you to set the theme for a documentation page through the URL.

Example:

https://carbon-svelte.vercel.app/components/InlineNotification?theme=g80#low-contrast