### PR TITLE
Improve documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" theme="white">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />

--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -44,7 +44,7 @@
 
 <p style="margin-bottom: var(--cds-layout-02)">
   Source code:
-  <OutboundLink inline href="{source}">
+  <OutboundLink size="lg" inline href="{source}">
     {component.filePath}
   </OutboundLink>
 </p>

--- a/docs/src/pages/_layout.svelte
+++ b/docs/src/pages/_layout.svelte
@@ -79,6 +79,11 @@
           >
             Carbon Charts Svelte
           </HeaderPanelLink>
+          <HeaderPanelLink
+            href="https://github.com/IBM/carbon-preprocess-svelte"
+          >
+            Carbon Preprocess Svelte
+          </HeaderPanelLink>
           <HeaderPanelDivider>Resources</HeaderPanelDivider>
           <HeaderPanelLink href="https://www.carbondesignsystem.com/">
             Carbon Design System

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -31,7 +31,7 @@ This component uses the native, asynchronous [Clipboard API](https://developer.m
 
 Please note that the `clipboard.writeText` API is not supported in [IE 11 nor Safari iOS version 13.3  or lower](https://caniuse.com/mdn-api_clipboard_writetext).
 
-You can override the default copy functionality with your own copy text implementation. See [Overriding copy functionality](#overriding-copy-functionality).
+You can override the default copy functionality with your own implementation. See [Overriding copy functionality](#overriding-copy-functionality).
 
 
 ### Default (single-line)

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -48,7 +48,7 @@ In this example, we use the open source module [clipboard-copy](https://github.c
 
 ### Preventing copy functionality
 
-To prevent text from being copied entirely, pass a "noop" function to the `copy` prop.
+To prevent text from being copied entirely, pass a no-op function to the `copy` prop.
 
 <CodeSnippet code="yarn add -D carbon-components-svelte" copy={() => {}} />
 

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -27,6 +27,6 @@ In this example, we use the open source module [clipboard-copy](https://github.c
 
 ### Preventing copy functionality
 
-To prevent text from being copied entirely, pass a "noop" function to the `copy` prop.
+To prevent text from being copied entirely, pass a no-op function to the `copy` prop.
 
 <CopyButton text="This text should not be copied" copy={() => {}} />

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -7,7 +7,7 @@ This component uses the native, asynchronous [Clipboard API](https://developer.m
 
 Please note that the `clipboard.writeText` API is not supported in [IE 11 nor Safari iOS version 13.3  or lower](https://caniuse.com/mdn-api_clipboard_writetext).
 
-You can override the default copy functionality with your own copy text implementation. See [Overriding copy functionality](#overriding-copy-functionality).
+You can override the default copy functionality with your own implementation. See [Overriding copy functionality](#overriding-copy-functionality).
 
 ### Default
 

--- a/docs/src/pages/components/RecursiveList.svx
+++ b/docs/src/pages/components/RecursiveList.svx
@@ -3,7 +3,7 @@
   import Preview from "../../components/Preview.svelte";
 </script>
 
-This component uses the [svelte:self API](https://svelte.dev/docs#svelte_self) to render the [UnorderedList](/components/UnorderedList) and [OrderedList](/components/OrderedList) components with data formatted as a tree structure. This is especially useful when the depth of the tree is unknown.
+This component uses the [svelte:self API](https://svelte.dev/docs#svelte_self) to render the [UnorderedList](/components/UnorderedList) and [OrderedList](/components/OrderedList) components with tree structured data.
 
 A child node can render text (`text`), a link (`href`), HTML content (`html`), and other `children`.
 

--- a/docs/src/pages/components/RecursiveList.svx
+++ b/docs/src/pages/components/RecursiveList.svx
@@ -5,7 +5,7 @@
 
 This component uses the [svelte:self API](https://svelte.dev/docs#svelte_self) to render the [UnorderedList](/components/UnorderedList) and [OrderedList](/components/OrderedList) components with tree structured data.
 
-A child node can render text (`text`), a link (`href`), HTML content (`html`), and other `children`.
+A child node can render text, a link, HTML content, and other children.
 
 <InlineNotification svx-ignore title="Warning:" kind="warning" hideCloseButton>
   <div class="body-short-01">

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -52,9 +52,13 @@
       <Column>
         <h3>Install</h3>
         <h4>Installing with yarn:</h4>
-        <CodeSnippet code="{installYarn}" />
+        <Row noGutter>
+          <CodeSnippet code="{installYarn}" />
+        </Row>
         <h4>Using npm:</h4>
-        <CodeSnippet code="{installNpm}" />
+        <Row noGutter>
+          <CodeSnippet code="{installNpm}" />
+        </Row>
       </Column>
     </Row>
     <Row>

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -90,6 +90,7 @@
     <Row noGutter>
       <Column xlg="{5}" lg="{8}" md="{4}">
         <TileCard
+          borderBottom
           borderRight
           title="Carbon Pictograms Svelte"
           subtitle="700+ pictograms"
@@ -99,10 +100,21 @@
       </Column>
       <Column xlg="{5}" lg="{8}" md="{4}">
         <TileCard
+          borderBottom
           title="Carbon Charts Svelte"
           subtitle="20 chart types, powered by d3"
           target="_blank"
           href="https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte"
+        />
+      </Column>
+    </Row>
+    <Row noGutter>
+      <Column xlg="{5}" lg="{8}" md="{4}">
+        <TileCard
+          title="Carbon Preprocess Svelte"
+          subtitle="Collection of Carbon Svelte preprocessors"
+          target="_blank"
+          href="https://github.com/IBM/carbon-preprocess-svelte"
         />
       </Column>
     </Row>

--- a/docs/src/store.js
+++ b/docs/src/store.js
@@ -1,3 +1,3 @@
 import { writable } from "svelte/store";
 
-export const theme = writable("g100");
+export const theme = writable("white");


### PR DESCRIPTION
**Documentation**

- fix typo in `CodeSnippet`, `CopyButton` pages; "noop" should be spelled "no-op"
- add `carbon-preprocess-svelte` to Carbon Svelte portfolio

---

Todo:

- [ ] Available themes
- [ ] Getting started (styling)
  - unpkg
  - pre-compiled CSS
  - SCSS