### PR TITLE
DatePicker rework

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1047,18 +1047,17 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                                 | Default value                                    | Description                                   |
-| :------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
-| value          | <code>let</code> | Yes      | <code>number &#124; string</code>                    | <code>""</code>                                  | Specify the date picker input value           |
-| datePickerType | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                            | Specify the date picker type                  |
-| appendTo       | <code>let</code> | No       | <code>HTMLElement</code>                             | --                                               | Specify the element to append the calendar to |
-| dateFormat     | <code>let</code> | No       | <code>string</code>                                  | <code>"m/d/Y"</code>                             | Specify the date format                       |
-| maxDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the maximum date                      |
-| minDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the minimum date                      |
-| locale         | <code>let</code> | No       | <code>string</code>                                  | <code>"en"</code>                                | Specify the locale                            |
-| short          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the short variant        |
-| light          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant     |
-| id             | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element         |
+| Prop name      | Kind             | Reactive | Type                                                 | Default value                                    | Description                               |
+| :------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | ----------------------------------------- |
+| value          | <code>let</code> | Yes      | <code>number &#124; string</code>                    | <code>""</code>                                  | Specify the date picker input value       |
+| datePickerType | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                            | Specify the date picker type              |
+| dateFormat     | <code>let</code> | No       | <code>string</code>                                  | <code>"m/d/Y"</code>                             | Specify the date format                   |
+| maxDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the maximum date                  |
+| minDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the minimum date                  |
+| locale         | <code>let</code> | No       | <code>string</code>                                  | <code>"en"</code>                                | Specify the locale                        |
+| short          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the short variant    |
+| light          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant |
+| id             | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element     |
 
 ### Slots
 
@@ -1068,13 +1067,13 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail |
-| :--------- | :--------- | :----- |
-| click      | forwarded  | --     |
-| mouseover  | forwarded  | --     |
-| mouseenter | forwarded  | --     |
-| mouseleave | forwarded  | --     |
-| change     | dispatched | --     |
+| Event name | Type       | Detail                                                                                                                              |
+| :--------- | :--------- | :---------------------------------------------------------------------------------------------------------------------------------- |
+| change     | dispatched | <code>string &#124; { selectedDates: [dateFrom: Date, dateTo?: Date]; dateStr: string &#124; { from: string; to: string; } }</code> |
+| click      | forwarded  | --                                                                                                                                  |
+| mouseover  | forwarded  | --                                                                                                                                  |
+| mouseenter | forwarded  | --                                                                                                                                  |
+| mouseleave | forwarded  | --                                                                                                                                  |
 
 ## `DatePickerInput`
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1047,17 +1047,19 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                                 | Default value                                    | Description                               |
-| :------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | ----------------------------------------- |
-| value          | <code>let</code> | Yes      | <code>number &#124; string</code>                    | <code>""</code>                                  | Specify the date picker input value       |
-| datePickerType | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                            | Specify the date picker type              |
-| dateFormat     | <code>let</code> | No       | <code>string</code>                                  | <code>"m/d/Y"</code>                             | Specify the date format                   |
-| maxDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the maximum date                  |
-| minDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the minimum date                  |
-| locale         | <code>let</code> | No       | <code>string</code>                                  | <code>"en"</code>                                | Specify the locale                        |
-| short          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the short variant    |
-| light          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant |
-| id             | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element     |
+| Prop name      | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                                       |
+| :------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| valueTo        | <code>let</code> | Yes      | <code>string</code>                                  | <code>""</code>                                  | Specify the date picker end date value (to)<br />Only works with the "range" date picker type     |
+| valueFrom      | <code>let</code> | Yes      | <code>string</code>                                  | <code>""</code>                                  | Specify the date picker start date value (from)<br />Only works with the "range" date picker type |
+| value          | <code>let</code> | Yes      | <code>number &#124; string</code>                    | <code>""</code>                                  | Specify the date picker input value                                                               |
+| datePickerType | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code> | <code>"simple"</code>                            | Specify the date picker type                                                                      |
+| dateFormat     | <code>let</code> | No       | <code>string</code>                                  | <code>"m/d/Y"</code>                             | Specify the date format                                                                           |
+| maxDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the maximum date                                                                          |
+| minDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>          | <code>null</code>                                | Specify the minimum date                                                                          |
+| locale         | <code>let</code> | No       | <code>string</code>                                  | <code>"en"</code>                                | Specify the locale                                                                                |
+| short          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the short variant                                                            |
+| light          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant                                                         |
+| id             | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element                                                             |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2393,15 +2393,6 @@
           "reactive": true
         },
         {
-          "name": "appendTo",
-          "kind": "let",
-          "description": "Specify the element to append the calendar to",
-          "type": "HTMLElement",
-          "isFunction": false,
-          "constant": false,
-          "reactive": false
-        },
-        {
           "name": "dateFormat",
           "kind": "let",
           "description": "Specify the date format",
@@ -2474,11 +2465,15 @@
       ],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "string | { selectedDates: [dateFrom: Date, dateTo?: Date]; dateStr: string | { from: string; to: string; } }"
+        },
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
         { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "dispatched", "name": "change" }
+        { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2393,6 +2393,26 @@
           "reactive": true
         },
         {
+          "name": "valueFrom",
+          "kind": "let",
+          "description": "Specify the date picker start date value (from)\nOnly works with the \"range\" date picker type",
+          "type": "string",
+          "value": "\"\"",
+          "isFunction": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
+          "name": "valueTo",
+          "kind": "let",
+          "description": "Specify the date picker end date value (to)\nOnly works with the \"range\" date picker type",
+          "type": "string",
+          "value": "\"\"",
+          "isFunction": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
           "name": "dateFormat",
           "kind": "let",
           "description": "Specify the date format",

--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -63,10 +63,7 @@ components: ["DatePicker", "DatePickerInput", "DatePickerSkeleton"]
 
 ### Range
 
-<DatePicker datePickerType="range" on:change>
-  <DatePickerInput labelText="Start date" placeholder="mm/dd/yyyy" />
-  <DatePickerInput labelText="End date" placeholder="mm/dd/yyyy" />
-</DatePicker>
+<FileSource src="/framed/DatePicker/DatePickerRange" />
 
 ### Skeleton
 

--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -57,9 +57,7 @@ components: ["DatePicker", "DatePickerInput", "DatePickerSkeleton"]
 
 ### Single
 
-<DatePicker datePickerType="single" on:change>
-  <DatePickerInput labelText="Schedule a meeting" placeholder="mm/dd/yyyy" />
-</DatePicker>
+<FileSource src="/framed/DatePicker/DatePickerSingle" />
 
 ### Range
 

--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -57,8 +57,15 @@ components: ["DatePicker", "DatePickerInput", "DatePickerSkeleton"]
 
 ### Single
 
-<DatePicker datePickerType="single">
+<DatePicker datePickerType="single" on:change>
   <DatePickerInput labelText="Schedule a meeting" placeholder="mm/dd/yyyy" />
+</DatePicker>
+
+### Range
+
+<DatePicker datePickerType="range" on:change>
+  <DatePickerInput labelText="Start date" placeholder="mm/dd/yyyy" />
+  <DatePickerInput labelText="End date" placeholder="mm/dd/yyyy" />
 </DatePicker>
 
 ### Skeleton

--- a/docs/src/pages/framed/DatePicker/DatePickerRange.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerRange.svelte
@@ -1,0 +1,8 @@
+<script>
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+</script>
+
+<DatePicker datePickerType="range" on:change>
+  <DatePickerInput labelText="Start date" placeholder="mm/dd/yyyy" />
+  <DatePickerInput labelText="End date" placeholder="mm/dd/yyyy" />
+</DatePicker>

--- a/docs/src/pages/framed/DatePicker/DatePickerSingle.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerSingle.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+</script>
+
+<DatePicker datePickerType="single" on:change>
+  <DatePickerInput labelText="Meeting date" placeholder="mm/dd/yyyy" />
+</DatePicker>

--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   optimizeDeps: {
-    include: ["clipboard-copy"],
+    include: ["clipboard-copy", "flatpickr/dist/plugins/rangePlugin"],
     exclude: ["@sveltech/routify"],
   },
 };

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -15,6 +15,20 @@
    */
   export let value = "";
 
+  /**
+   * Specify the date picker start date value (from)
+   * Only works with the "range" date picker type
+   * @type {string}
+   */
+  export let valueFrom = "";
+
+  /**
+   * Specify the date picker end date value (to)
+   * Only works with the "range" date picker type
+   * @type {string}
+   */
+  export let valueTo = "";
+
   /** Specify the date format */
   export let dateFormat = "m/d/Y";
 
@@ -59,6 +73,8 @@
     (_) => _.filter(({ labelText }) => !!labelText).length === 0
   );
   const inputValue = writable(value);
+  const inputValueFrom = writable(valueFrom);
+  const inputValueTo = writable(valueTo);
   const mode = writable(datePickerType);
   const range = derived(mode, (_) => _ === "range");
   const hasCalendar = derived(mode, (_) => _ === "single" || _ === "range");
@@ -71,6 +87,9 @@
   setContext("DatePicker", {
     range,
     inputValue,
+    inputValueFrom,
+    inputValueTo,
+    inputIds,
     hasCalendar,
     add: (data) => {
       inputs.update((_) => [..._, data]);
@@ -127,10 +146,16 @@
           const detail = { selectedDates: calendar.selectedDates };
 
           if ($range) {
+            const from = inputRef.value;
+            const to = inputRefTo.value;
+
             detail.dateStr = {
               from: inputRef.value,
               to: inputRefTo.value,
             };
+
+            valueFrom = from;
+            valueTo = to;
           } else {
             detail.dateStr = inputRef.value;
           }
@@ -140,8 +165,15 @@
       });
     }
 
-    if (calendar && !$range) {
-      calendar.setDate($inputValue);
+    if (calendar) {
+      if ($range) {
+        calendar.setDate([$inputValueFrom, $inputValueTo]);
+
+        // workaround to remove the default range plugin separator "to"
+        inputRef.value = $inputValueFrom;
+      } else {
+        calendar.setDate($inputValue);
+      }
     }
   });
 
@@ -153,6 +185,10 @@
 
   $: inputValue.set(value);
   $: value = $inputValue;
+  $: inputValueFrom.set(valueFrom);
+  $: valueFrom = $inputValueFrom;
+  $: inputValueTo.set(valueTo);
+  $: valueTo = $inputValueTo;
 </script>
 
 <svelte:body

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -15,12 +15,6 @@
    */
   export let value = "";
 
-  /**
-   * Specify the element to append the calendar to
-   * @type {HTMLElement}
-   */
-  export let appendTo = document.body;
-
   /** Specify the date format */
   export let dateFormat = "m/d/Y";
 
@@ -69,10 +63,10 @@
   const range = derived(mode, (_) => _ === "range");
   const hasCalendar = derived(mode, (_) => _ === "single" || _ === "range");
 
-  let calendar = undefined;
-  let datePickerRef = undefined;
-  let inputRef = undefined;
-  let inputRefTo = undefined;
+  let calendar = null;
+  let datePickerRef = null;
+  let inputRef = null;
+  let inputRefTo = null;
 
   setContext("DatePicker", {
     range,
@@ -119,7 +113,7 @@
     if ($hasCalendar && !calendar) {
       calendar = createCalendar({
         options: {
-          appendTo,
+          appendTo: datePickerRef,
           dateFormat,
           defaultDate: $inputValue,
           locale,
@@ -163,15 +157,9 @@
 
 <svelte:body
   on:click="{({ target }) => {
-    if (!calendar || !calendar.isOpen) {
-      return;
-    }
-    if (datePickerRef && datePickerRef.contains(target)) {
-      return;
-    }
-    if (!calendar.calendarContainer.contains(target)) {
-      calendar.close();
-    }
+    if (!calendar || !calendar.isOpen) return;
+    if (datePickerRef && datePickerRef.contains(target)) return;
+    if (!calendar.calendarContainer.contains(target)) calendar.close();
   }}" />
 
 <div

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @dispatch {string} change
+   * @event {string | { selectedDates: [dateFrom: Date, dateTo?: Date]; dateStr: string | { from: string; to: string; } }} change
    */
 
   /**

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -60,11 +60,14 @@
     add,
     hasCalendar,
     declareRef,
+    inputIds,
     updateValue,
     blurInput,
     openCalendar,
     focusCalendar,
     inputValue,
+    inputValueFrom,
+    inputValueTo,
   } = getContext("DatePicker");
 
   add({ id, labelText });
@@ -105,7 +108,11 @@
       pattern="{pattern}"
       disabled="{disabled}"
       {...$$restProps}
-      value="{!$range ? $inputValue : undefined}"
+      value="{$range
+        ? $inputIds.indexOf(id) === 0
+          ? $inputValueFrom
+          : $inputValueTo
+        : $inputValue}"
       class:bx--date-picker__input="{true}"
       class:bx--date-picker__input--invalid="{invalid}"
       class="{size && `bx--date-picker__input--${size}`}"

--- a/src/DatePicker/createCalendar.js
+++ b/src/DatePicker/createCalendar.js
@@ -1,5 +1,5 @@
 import flatpickr from "flatpickr";
-import rangePlugin from "flatpickr/dist/esm/plugins/rangePlugin";
+import rangePlugin from "flatpickr/dist/plugins/rangePlugin";
 
 let l10n;
 

--- a/tests/DatePicker.test.svelte
+++ b/tests/DatePicker.test.svelte
@@ -2,7 +2,11 @@
   import { DatePicker, DatePickerSkeleton, DatePickerInput } from "../types";
 </script>
 
-<DatePicker>
+<DatePicker
+  on:change="{(e) => {
+    console.log(e.detail);
+  }}"
+>
   <DatePickerInput labelText="Date of birth" placeholder="mm/dd/yyyy" />
 </DatePicker>
 
@@ -51,7 +55,7 @@
   />
 </DatePicker>
 
-<DatePicker datePickerType="single">
+<DatePicker valueFrom="" valueTo="" datePickerType="single">
   <DatePickerInput labelText="Schedule a meeting" placeholder="mm/dd/yyyy" />
 </DatePicker>
 

--- a/types/DatePicker/DatePicker.d.ts
+++ b/types/DatePicker/DatePicker.d.ts
@@ -16,11 +16,6 @@ export interface DatePickerProps
   value?: number | string;
 
   /**
-   * Specify the element to append the calendar to
-   */
-  appendTo?: HTMLElement;
-
-  /**
    * Specify the date format
    * @default "m/d/Y"
    */
@@ -66,11 +61,17 @@ export interface DatePickerProps
 export default class DatePicker extends SvelteComponentTyped<
   DatePickerProps,
   {
+    change: CustomEvent<
+      | string
+      | {
+          selectedDates: [dateFrom: Date, dateTo?: Date];
+          dateStr: string | { from: string; to: string };
+        }
+    >;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
-    change: CustomEvent<any>;
   },
   { default: {} }
 > {}

--- a/types/DatePicker/DatePicker.d.ts
+++ b/types/DatePicker/DatePicker.d.ts
@@ -16,6 +16,20 @@ export interface DatePickerProps
   value?: number | string;
 
   /**
+   * Specify the date picker start date value (from)
+   * Only works with the "range" date picker type
+   * @default ""
+   */
+  valueFrom?: string;
+
+  /**
+   * Specify the date picker end date value (to)
+   * Only works with the "range" date picker type
+   * @default ""
+   */
+  valueTo?: string;
+
+  /**
    * Specify the date format
    * @default "m/d/Y"
    */


### PR DESCRIPTION
This PR address some long standing issues with the `DatePicker` component.

Fixes #573 , fixes #345 , fixes #522

- [x] appending the `DatePicker` calendar to `document.body` locks the arrow keys in other input fields (#345, #573)
- [x] SSR-compatibility issues caused by `appendTo` prop (#522)
- [ ] [cannot reproduce] single `DatePicker` does not dispatch `on:change` event (#314)
- [x] range `DatePicker` does not provide start/end values to bind to (#234)
- [x] typing for `on:change` event is incorrect
- [x] importing the rangePlugin from the `esm` folder throws an error
- [x] add range `DatePicker` example to documentation

---

**Breaking Changes**

- remove `appendTo` prop in `DatePicker` as it is no longer needed; this also makes the `DatePicker` component compatible in server-side rendering (SSR) environments (#522)

**Fixes**

- append calendar to the date picker element instead of `document.body` to prevent locking of the arrow keys in other input elements (suggested fix by @timeshift92), (#345, #573)
- fix `rangePlugin` import in `DatePicker` to fix "Unexpected token export" error