### PR TITLE
Fix TypeScript definitions; function declarations should be typed as accessors, not props

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -12,6 +12,7 @@
           "type": "\"start\" | \"end\"",
           "value": "\"end\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -21,6 +22,7 @@
           "description": "Specify the size of the accordion",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -31,6 +33,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -41,6 +44,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -86,6 +90,7 @@
           "type": "string",
           "value": "\"title\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -96,6 +101,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -106,6 +112,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -116,6 +123,7 @@
           "type": "string",
           "value": "\"Expand/Collapse\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -151,6 +159,7 @@
           "type": "number",
           "value": "4",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -161,6 +170,7 @@
           "type": "\"start\" | \"end\"",
           "value": "\"end\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -170,6 +180,7 @@
           "description": "Specify the size of the accordion",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -180,6 +191,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -205,6 +217,7 @@
           "type": "\"2x1\" | \"16x9\" | \"4x3\" | \"1x1\" | \"3x4\" | \"3x2\" | \"9x16\" | \"1x2\"",
           "value": "\"2x1\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -225,6 +238,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -235,6 +249,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -279,6 +294,7 @@
           "description": "Set the `href` to use an anchor link",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -289,6 +305,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -320,6 +337,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -330,6 +348,7 @@
           "type": "number",
           "value": "3",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -354,6 +373,7 @@
           "description": "Determine the current Carbon grid breakpoint size",
           "type": "BreakpointSize",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -364,6 +384,7 @@
           "type": "Record<BreakpointSize, boolean>",
           "value": "{     sm: false,     md: false,     lg: false,     xlg: false,     max: false,   }",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -374,6 +395,7 @@
           "type": "Record<BreakpointSize, BreakpointValue>",
           "value": "{     sm: 320,     md: 672,     lg: 1056,     xlg: 1312,     max: 1584,   }",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": true,
           "reactive": false
         }
@@ -416,6 +438,7 @@
           "type": "\"primary\" | \"secondary\" | \"tertiary\" | \"ghost\" | \"danger\" | \"danger-tertiary\" | \"danger-ghost\"",
           "value": "\"primary\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -426,6 +449,7 @@
           "type": "\"default\" | \"field\" | \"small\" | \"lg\" | \"xl\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -436,6 +460,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -446,6 +471,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -456,6 +482,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -465,6 +492,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -474,6 +502,7 @@
           "description": "Specify the ARIA label for the button icon",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -484,6 +513,7 @@
           "type": "\"start\" | \"center\" | \"end\"",
           "value": "\"center\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -494,6 +524,7 @@
           "type": "\"top\" | \"right\" | \"bottom\" | \"left\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -504,6 +535,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -514,6 +546,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -524,6 +557,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -533,6 +567,7 @@
           "description": "Set the `href` to use an anchor link",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -543,6 +578,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -553,6 +589,7 @@
           "type": "string",
           "value": "\"button\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -563,6 +600,7 @@
           "type": "null | HTMLAnchorElement | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -610,6 +648,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -629,6 +668,7 @@
           "description": "Set the `href` to use an anchor link",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -639,6 +679,7 @@
           "type": "\"default\" | \"field\" | \"small\" | \"lg\" | \"xl\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -648,6 +689,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -673,6 +715,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -683,6 +726,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -693,6 +737,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -703,6 +748,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -713,6 +759,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -723,6 +770,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -733,6 +781,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -743,6 +792,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -752,6 +802,7 @@
           "description": "Specify the title attribute for the label element",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -762,6 +813,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -772,6 +824,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -833,6 +886,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -843,6 +897,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -853,6 +908,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -862,6 +918,7 @@
           "description": "Set the `href`",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -888,6 +945,7 @@
           "type": "\"single\" | \"inline\" | \"multi\"",
           "value": "\"single\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -897,6 +955,7 @@
           "description": "Set the code snippet text\nAlternatively, use the default slot (e.g., <CodeSnippet>{`code`}</CodeSnippet>)\nYou must use the `code` prop to copy the code",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -907,6 +966,7 @@
           "type": "(code: string) => void",
           "value": "async (code) => {     try {       await navigator.clipboard.writeText(code);     } catch (e) {       console.log(e);     }   }",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -917,6 +977,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -927,6 +988,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -937,6 +999,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -947,6 +1010,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -957,6 +1021,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -967,6 +1032,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -976,6 +1042,7 @@
           "description": "Specify the ARIA label for the copy button icon",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -985,6 +1052,7 @@
           "description": "Specify the ARIA label of the copy button",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -995,6 +1063,7 @@
           "type": "string",
           "value": "\"Copied!\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1005,6 +1074,7 @@
           "type": "number",
           "value": "2000",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1015,6 +1085,7 @@
           "type": "string",
           "value": "\"Show less\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1025,6 +1096,7 @@
           "type": "string",
           "value": "\"Show more\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1035,6 +1107,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1045,6 +1118,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1055,6 +1129,7 @@
           "type": "null | HTMLPreElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -1109,6 +1184,7 @@
           "type": "\"single\" | \"multi\"",
           "value": "\"single\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -1134,6 +1210,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1144,6 +1221,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1154,6 +1232,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1164,6 +1243,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1174,6 +1254,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1183,6 +1264,7 @@
           "description": "Specify the aspect ratio of the column",
           "type": "\"2x1\" | \"16x9\" | \"9x16\" | \"1x2\" | \"4x3\" | \"3x4\" | \"1x1\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1192,6 +1274,7 @@
           "description": "Set the small breakpoint",
           "type": "ColumnBreakpoint",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1201,6 +1284,7 @@
           "description": "Set the medium breakpoint",
           "type": "ColumnBreakpoint",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1210,6 +1294,7 @@
           "description": "Set the large breakpoint",
           "type": "ColumnBreakpoint",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1219,6 +1304,7 @@
           "description": "Set the extra large breakpoint",
           "type": "ColumnBreakpoint",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1228,6 +1314,7 @@
           "description": "Set the maximum breakpoint",
           "type": "ColumnBreakpoint",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -1270,6 +1357,7 @@
           "type": "ComboBoxItem[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1280,6 +1368,7 @@
           "type": "(item: ComboBoxItem) => string",
           "value": "(item) => item.text || item.id",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1290,6 +1379,7 @@
           "type": "number",
           "value": "-1",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1300,6 +1390,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1310,6 +1401,7 @@
           "type": "\"bottom\" | \"top\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1319,6 +1411,7 @@
           "description": "Set the size of the combobox",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1329,6 +1422,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1339,6 +1433,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1349,6 +1444,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1359,6 +1455,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1369,6 +1466,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1379,6 +1477,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1389,6 +1488,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1399,6 +1499,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1409,6 +1510,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1419,6 +1521,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1429,6 +1532,7 @@
           "type": "(item: ComboBoxItem, value: string) => boolean",
           "value": "() => true",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1438,6 +1542,7 @@
           "description": "Override the default translation ids",
           "type": "(id: any) => string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1448,6 +1553,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1457,6 +1563,7 @@
           "description": "Specify a name attribute for the input",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1467,6 +1574,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1477,6 +1585,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -1514,6 +1623,7 @@
           "description": "Set the size of the composed modal",
           "type": "\"xs\" | \"sm\" | \"lg\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1524,6 +1634,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1534,6 +1645,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1544,6 +1656,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1554,6 +1667,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1564,6 +1678,7 @@
           "type": "null | string",
           "value": "\"[data-modal-primary-focus]\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1574,6 +1689,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -1609,6 +1725,7 @@
           "type": "string",
           "value": "\"main-content\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -1629,6 +1746,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1639,6 +1757,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1648,6 +1767,7 @@
           "description": "Specify the size of the content switcher",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -1674,6 +1794,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1684,6 +1805,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1694,6 +1816,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1704,6 +1827,7 @@
           "type": "null | HTMLUListElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -1736,6 +1860,7 @@
           "type": "string[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1746,6 +1871,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -1765,6 +1891,7 @@
           "type": "\"default\" | \"danger\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1775,6 +1902,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1785,6 +1913,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1794,6 +1923,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render\nIcon is rendered to the left of the label text",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1804,6 +1934,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1814,6 +1945,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1824,6 +1956,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1834,6 +1967,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1844,6 +1978,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1854,6 +1989,7 @@
           "type": "null | HTMLLIElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -1893,6 +2029,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -1903,6 +2040,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -1922,6 +2060,7 @@
           "type": "string",
           "value": "\"Copied!\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1932,6 +2071,7 @@
           "type": "number",
           "value": "2000",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1942,6 +2082,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -1972,6 +2113,7 @@
           "type": "string",
           "value": "\"Copy to clipboard\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1981,6 +2123,7 @@
           "description": "Specify the text to copy",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -1991,6 +2134,7 @@
           "type": "(text: string) => void",
           "value": "async (text) => {     try {       await navigator.clipboard.writeText(text);     } catch (e) {       console.log(e);     }   }",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -2016,6 +2160,7 @@
           "type": "DataTableHeader[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2026,6 +2171,7 @@
           "type": "DataTableRow[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2035,6 +2181,7 @@
           "description": "Set the size of the data table",
           "type": "\"compact\" | \"short\" | \"medium\" | \"tall\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2045,6 +2192,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2055,6 +2203,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2065,6 +2214,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2075,6 +2225,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2085,6 +2236,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2095,6 +2247,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2105,6 +2258,7 @@
           "type": "DataTableRowId[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2115,6 +2269,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2125,6 +2280,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2135,6 +2291,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2145,6 +2302,7 @@
           "type": "DataTableRowId[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2155,6 +2313,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2165,6 +2324,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -2294,6 +2454,7 @@
           "type": "number",
           "value": "5",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2304,6 +2465,7 @@
           "type": "number",
           "value": "5",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2313,6 +2475,7 @@
           "description": "Set the size of the data table",
           "type": "\"compact\" | \"short\" | \"tall\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2323,6 +2486,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2333,6 +2497,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2343,6 +2508,7 @@
           "type": "string[] | Partial<DataTableHeader>[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2353,6 +2519,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -2379,6 +2546,7 @@
           "type": "\"simple\" | \"single\" | \"range\"",
           "value": "\"simple\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2389,6 +2557,7 @@
           "type": "number | string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2399,6 +2568,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2409,6 +2579,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2419,6 +2590,7 @@
           "type": "string",
           "value": "\"m/d/Y\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2429,6 +2601,7 @@
           "type": "null | string | Date",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2439,6 +2612,7 @@
           "type": "null | string | Date",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2449,6 +2623,7 @@
           "type": "string",
           "value": "\"en\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2459,6 +2634,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2469,6 +2645,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2479,6 +2656,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -2508,6 +2686,7 @@
           "description": "Set the size of the input",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2518,6 +2697,7 @@
           "type": "string",
           "value": "\"text\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2528,6 +2708,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2538,6 +2719,7 @@
           "type": "string",
           "value": "\"\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2548,6 +2730,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2558,6 +2741,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2568,6 +2752,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2578,6 +2763,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2588,6 +2774,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2598,6 +2785,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2608,6 +2796,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2618,6 +2807,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2628,6 +2818,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2637,6 +2828,7 @@
           "description": "Set a name for the input element",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2647,6 +2839,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -2679,6 +2872,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2689,6 +2883,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -2714,6 +2909,7 @@
           "type": "DropdownItem[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2724,6 +2920,7 @@
           "type": "(item: DropdownItem) => string",
           "value": "(item) => item.text || item.id",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2734,6 +2931,7 @@
           "type": "number",
           "value": "-1",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2744,6 +2942,7 @@
           "type": "\"default\" | \"inline\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2754,6 +2953,7 @@
           "type": "\"bottom\" | \"top\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2763,6 +2963,7 @@
           "description": "Specify the size of the dropdown field",
           "type": "\"sm\" | \"lg\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2773,6 +2974,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2783,6 +2985,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2793,6 +2996,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2803,6 +3007,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2813,6 +3018,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2823,6 +3029,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2833,6 +3040,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2843,6 +3051,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2853,6 +3062,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2863,6 +3073,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2872,6 +3083,7 @@
           "description": "Specify the list box label",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2882,6 +3094,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2891,6 +3104,7 @@
           "description": "Override the default translation ids",
           "type": "(id: any) => string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2901,6 +3115,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2910,6 +3125,7 @@
           "description": "Specify a name attribute for the list box",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -2920,6 +3136,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -2962,6 +3179,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -2987,6 +3205,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -2997,6 +3216,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3007,6 +3227,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -3017,6 +3238,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -3027,6 +3249,7 @@
           "type": "string",
           "value": "\"Interact to expand Tile\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3037,6 +3260,7 @@
           "type": "string",
           "value": "\"Interact to collapse Tile\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3047,6 +3271,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3057,6 +3282,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3067,6 +3293,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3077,6 +3304,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3087,6 +3315,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -3116,6 +3345,7 @@
           "type": "\"uploading\" | \"edit\" | \"complete\"",
           "value": "\"uploading\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3126,6 +3356,7 @@
           "type": "string[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3136,6 +3367,7 @@
           "type": "File[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -3146,6 +3378,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3156,6 +3389,7 @@
           "type": "() => void",
           "value": "() => {     files = [];   }",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": true,
           "reactive": false
         },
@@ -3166,6 +3400,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3176,6 +3411,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3186,6 +3422,7 @@
           "type": "\"primary\" | \"secondary\" | \"tertiary\" | \"ghost\" | \"danger\"",
           "value": "\"primary\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3196,6 +3433,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3206,6 +3444,7 @@
           "type": "string",
           "value": "\"Provide icon description\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3216,6 +3455,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -3249,6 +3489,7 @@
           "type": "string[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3259,6 +3500,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3269,6 +3511,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3279,6 +3522,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3289,6 +3533,7 @@
           "type": "\"primary\" | \"secondary\" | \"tertiary\" | \"ghost\" | \"danger\"",
           "value": "\"primary\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3299,6 +3544,7 @@
           "type": "string",
           "value": "\"Add file\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -3309,6 +3555,7 @@
           "type": "string",
           "value": "\"button\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3319,6 +3566,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3329,6 +3577,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3339,6 +3588,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3349,6 +3599,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -3380,6 +3631,7 @@
           "type": "string[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3390,6 +3642,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3400,6 +3653,7 @@
           "type": "(files: FileList) => FileList",
           "value": "(files) => files",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3410,6 +3664,7 @@
           "type": "string",
           "value": "\"Add file\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3420,6 +3675,7 @@
           "type": "string",
           "value": "\"button\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3430,6 +3686,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3440,6 +3697,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3450,6 +3708,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3460,6 +3719,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3470,6 +3730,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -3505,6 +3766,7 @@
           "type": "\"uploading\" | \"edit\" | \"complete\"",
           "value": "\"uploading\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3515,6 +3777,7 @@
           "type": "\"default\" | \"field\" | \"small\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3525,6 +3788,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3535,6 +3799,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3545,6 +3810,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3555,6 +3821,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3565,6 +3832,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3575,6 +3843,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -3614,6 +3883,7 @@
           "type": "\"uploading\" | \"edit\" | \"complete\"",
           "value": "\"uploading\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3624,6 +3894,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3634,6 +3905,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -3689,6 +3961,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3699,6 +3972,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3709,6 +3983,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3719,6 +3994,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3729,6 +4005,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3739,6 +4016,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -3778,6 +4056,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -3803,6 +4082,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3813,6 +4093,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3823,6 +4104,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3833,6 +4115,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3843,6 +4126,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3853,6 +4137,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3863,6 +4148,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3873,6 +4159,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -3899,6 +4186,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3909,6 +4197,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -3918,6 +4207,7 @@
           "description": "Specify the ARIA label for the header",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3927,6 +4217,7 @@
           "description": "Specify the `href` attribute",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3936,6 +4227,7 @@
           "description": "Specify the company name",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3946,6 +4238,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3956,6 +4249,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3966,6 +4260,7 @@
           "type": "number",
           "value": "1056",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3976,6 +4271,7 @@
           "type": "null | HTMLAnchorElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -3985,6 +4281,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render for the closed state\nDefaults to `Menu20`",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -3994,6 +4291,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render for the opened state\nDefaults to `Close20`",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -4023,6 +4321,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4032,6 +4331,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4041,6 +4341,7 @@
           "description": "Specify the text\nAlternatively, use the named slot \"text\" (e.g., <div slot=\"text\">...</div>)",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4051,6 +4352,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4061,6 +4363,7 @@
           "type": "false | HeaderActionSlideTransition",
           "value": "{ duration: 200 }",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -4098,6 +4401,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4107,6 +4411,7 @@
           "description": "Specify the `href` attribute",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4116,6 +4421,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4126,6 +4432,7 @@
           "type": "null | HTMLAnchorElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -4146,6 +4453,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -4173,6 +4481,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4182,6 +4491,7 @@
           "description": "Specify the icon to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4192,6 +4502,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -4218,6 +4529,7 @@
           "description": "Specify the ARIA label for the nav",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -4237,6 +4549,7 @@
           "description": "Specify the `href` attribute",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4246,6 +4559,7 @@
           "description": "Specify the text",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4256,6 +4570,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4266,6 +4581,7 @@
           "type": "null | HTMLAnchorElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -4295,6 +4611,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4305,6 +4622,7 @@
           "type": "string",
           "value": "\"/\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4314,6 +4632,7 @@
           "description": "Specify the text",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4324,6 +4643,7 @@
           "type": "null | HTMLAnchorElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -4360,6 +4680,7 @@
           "description": "Specify the `href` attribute",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4370,6 +4691,7 @@
           "type": "null | HTMLAnchorElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -4398,6 +4720,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4408,6 +4731,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4418,6 +4742,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4428,6 +4753,7 @@
           "type": "HeaderSearchResult[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4438,6 +4764,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -4492,6 +4819,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4502,6 +4830,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -4535,6 +4864,7 @@
           "type": "number",
           "value": "16",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -4560,6 +4890,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4570,6 +4901,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4579,6 +4911,7 @@
           "description": "Specify the aspect ratio for the image wrapper",
           "type": "\"2x1\" | \"16x9\" | \"4x3\" | \"1x1\" | \"3x4\" | \"3x2\" | \"9x16\" | \"1x2\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4589,6 +4922,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4599,6 +4933,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4609,6 +4944,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -4619,6 +4955,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4629,6 +4966,7 @@
           "type": "(url?: string) => void",
           "value": "(url) => {     if (image != null) image = null;     loaded = false;     error = false;     image = new Image();     image.src = url || src;     image.onload = () => (loaded = true);     image.onerror = () => (error = true);   }",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": true,
           "reactive": false
         }
@@ -4655,6 +4993,7 @@
           "type": "\"active\" | \"inactive\" | \"finished\" | \"error\"",
           "value": "\"active\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4664,6 +5003,7 @@
           "description": "Set the loading description",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4673,6 +5013,7 @@
           "description": "Specify the ARIA label for the loading icon",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4683,6 +5024,7 @@
           "type": "number",
           "value": "1500",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -4709,6 +5051,7 @@
           "type": "\"error\" | \"info\" | \"info-square\" | \"success\" | \"warning\" | \"warning-alt\"",
           "value": "\"error\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4719,6 +5062,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4729,6 +5073,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4739,6 +5084,7 @@
           "type": "string",
           "value": "\"alert\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4749,6 +5095,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4759,6 +5106,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4769,6 +5117,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4779,6 +5128,7 @@
           "type": "string",
           "value": "\"Closes notification\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -4811,6 +5161,7 @@
           "description": "Specify the size of the link",
           "type": "\"sm\" | \"lg\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4820,6 +5171,7 @@
           "description": "Specify the href value",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4830,6 +5182,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4839,6 +5192,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render\n`inline` must be `false`",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4849,6 +5203,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4859,6 +5214,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4869,6 +5225,7 @@
           "type": "null | HTMLAnchorElement | HTMLParagraphElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -4893,6 +5250,7 @@
           "description": "Set the size of the list box",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4903,6 +5261,7 @@
           "type": "\"default\" | \"inline\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4913,6 +5272,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4923,6 +5283,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4933,6 +5294,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4943,6 +5305,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4953,6 +5316,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4963,6 +5327,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -4973,6 +5338,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -4996,6 +5362,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5006,6 +5373,7 @@
           "type": "string",
           "value": "\"combobox\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5016,6 +5384,7 @@
           "type": "string",
           "value": "\"-1\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5026,6 +5395,7 @@
           "type": "{ close: \"close\", open: \"open\" }",
           "value": "{ close: \"close\", open: \"open\" }",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": true,
           "reactive": false
         },
@@ -5036,6 +5406,7 @@
           "type": "(id: ListBoxFieldTranslationId) => string",
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5046,6 +5417,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5056,6 +5428,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -5090,6 +5463,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5100,6 +5474,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -5120,6 +5495,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5130,6 +5506,7 @@
           "type": "{ close: \"close\", open: \"open\" }",
           "value": "{ close: \"close\", open: \"open\" }",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": true,
           "reactive": false
         },
@@ -5140,6 +5517,7 @@
           "type": "(id: ListBoxMenuIconTranslationId) => string",
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -5166,6 +5544,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5176,6 +5555,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -5199,6 +5579,7 @@
           "description": "Specify the number of selected items",
           "type": "number",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5209,6 +5590,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5219,6 +5601,7 @@
           "type": "{     clearAll: \"clearAll\",     clearSelection: \"clearSelection\",   }",
           "value": "{     clearAll: \"clearAll\",     clearSelection: \"clearSelection\",   }",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": true,
           "reactive": false
         },
@@ -5229,6 +5612,7 @@
           "type": "(id: ListBoxSelectionTranslationId) => string",
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5239,6 +5623,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -5279,6 +5664,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5289,6 +5675,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5299,6 +5686,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5309,6 +5697,7 @@
           "type": "string",
           "value": "\"Active loading indicator\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5319,6 +5708,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -5339,6 +5729,7 @@
           "type": "string",
           "value": "\"local-storage-key\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5349,6 +5740,7 @@
           "type": "any",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -5359,6 +5751,7 @@
           "type": "() => void",
           "value": "() => {     localStorage.removeItem(key);   }",
           "isFunction": true,
+          "isFunctionDeclaration": true,
           "constant": false,
           "reactive": false
         },
@@ -5369,6 +5762,7 @@
           "type": "() => void",
           "value": "() => {     localStorage.clear();   }",
           "isFunction": true,
+          "isFunctionDeclaration": true,
           "constant": false,
           "reactive": false
         }
@@ -5394,6 +5788,7 @@
           "description": "Set the size of the modal",
           "type": "\"xs\" | \"sm\" | \"lg\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5404,6 +5799,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -5414,6 +5810,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5424,6 +5821,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5434,6 +5832,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5443,6 +5842,7 @@
           "description": "Specify the modal heading",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5452,6 +5852,7 @@
           "description": "Specify the modal label",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5461,6 +5862,7 @@
           "description": "Specify the ARIA label for the modal",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5471,6 +5873,7 @@
           "type": "string",
           "value": "\"Close the modal\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5481,6 +5884,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5491,6 +5895,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5501,6 +5906,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5511,6 +5917,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5521,6 +5928,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5531,6 +5939,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5541,6 +5950,7 @@
           "type": "[{ text: string; }, { text: string; }]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5551,6 +5961,7 @@
           "type": "string",
           "value": "\"[data-modal-primary-focus]\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5561,6 +5972,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5571,6 +5983,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5581,6 +5994,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -5635,6 +6049,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5645,6 +6060,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -5665,6 +6081,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5675,6 +6092,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5684,6 +6102,7 @@
           "description": "Specify a class for the primary button",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5694,6 +6113,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5704,6 +6124,7 @@
           "type": "[{ text: string; }, { text: string; }]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5713,6 +6134,7 @@
           "description": "Specify a class for the secondary button",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5723,6 +6145,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -5749,6 +6172,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5759,6 +6183,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5769,6 +6194,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5779,6 +6205,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5789,6 +6216,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5799,6 +6227,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5809,6 +6238,7 @@
           "type": "string",
           "value": "\"Close\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -5829,6 +6259,7 @@
           "type": "MultiSelectItem[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -5839,6 +6270,7 @@
           "type": "(item: MultiSelectItem) => string",
           "value": "(item) => item.text || item.id",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5849,6 +6281,7 @@
           "type": "MultiSelectItemId[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -5859,6 +6292,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -5868,6 +6302,7 @@
           "description": "Set the size of the combobox",
           "type": "\"sm\" | \"lg\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5878,6 +6313,7 @@
           "type": "\"default\" | \"inline\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5888,6 +6324,7 @@
           "type": "\"bottom\" | \"top\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5898,6 +6335,7 @@
           "type": "\"top\" | \"fixed\" | \"top-after-reopen\"",
           "value": "\"top-after-reopen\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5908,6 +6346,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5918,6 +6357,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5928,6 +6368,7 @@
           "type": "(item: MultiSelectItem, value: string) => string",
           "value": "(item, value) =>     item.text.toLowerCase().includes(value.toLowerCase())",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5938,6 +6379,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -5948,6 +6390,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5958,6 +6401,7 @@
           "type": "string",
           "value": "\"en\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5968,6 +6412,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5978,6 +6423,7 @@
           "type": "((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) | (() => void)",
           "value": "(a, b) =>     a.text.localeCompare(b.text, locale, { numeric: true })",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5987,6 +6433,7 @@
           "description": "Override the default translation ids",
           "type": "(id: any) => string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -5997,6 +6444,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6007,6 +6455,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6017,6 +6466,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6027,6 +6477,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6037,6 +6488,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6047,6 +6499,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6057,6 +6510,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6067,6 +6521,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6077,6 +6532,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6086,6 +6542,7 @@
           "description": "Specify a name attribute for the select",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6096,6 +6553,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6106,6 +6564,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6116,6 +6575,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6126,6 +6586,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -6187,6 +6648,7 @@
           "type": "\"toast\" | \"inline\"",
           "value": "\"toast\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6196,6 +6658,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6205,6 +6668,7 @@
           "description": "Specify the title of the icon",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6215,6 +6679,7 @@
           "type": "string",
           "value": "\"Close icon\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -6240,6 +6705,7 @@
           "type": "\"error\" | \"info\" | \"info-square\" | \"success\" | \"warning\" | \"warning-alt\"",
           "value": "\"error\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6250,6 +6716,7 @@
           "type": "\"toast\" | \"inline\"",
           "value": "\"toast\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6260,6 +6727,7 @@
           "type": "string",
           "value": "\"Closes notification\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -6279,6 +6747,7 @@
           "type": "\"toast\" | \"inline\"",
           "value": "\"toast\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6289,6 +6758,7 @@
           "type": "string",
           "value": "\"Title\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6299,6 +6769,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6309,6 +6780,7 @@
           "type": "string",
           "value": "\"Caption\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -6327,6 +6799,7 @@
           "description": "Set the size of the input",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6337,6 +6810,7 @@
           "type": "number | string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6347,6 +6821,7 @@
           "type": "number",
           "value": "1",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6356,6 +6831,7 @@
           "description": "Specify the maximum value",
           "type": "number",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6365,6 +6841,7 @@
           "description": "Specify the minimum value",
           "type": "number",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6375,6 +6852,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6385,6 +6863,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6395,6 +6874,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6405,6 +6885,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6415,6 +6896,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6425,6 +6907,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6435,6 +6918,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6445,6 +6929,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6455,6 +6940,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6465,6 +6951,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6475,6 +6962,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6485,6 +6973,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6495,6 +6984,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6505,6 +6995,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6515,6 +7006,7 @@
           "type": "(id: NumberInputTranslationId) => string",
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6525,6 +7017,7 @@
           "type": "{ increment: \"increment\"; decrement: \"decrement\" }",
           "value": "{     increment: \"increment\",     decrement: \"decrement\",   }",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": true,
           "reactive": false
         },
@@ -6535,6 +7028,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6544,6 +7038,7 @@
           "description": "Specify a name attribute for the input",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6554,6 +7049,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -6594,6 +7090,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -6619,6 +7116,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6629,6 +7127,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6639,6 +7138,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -6678,6 +7178,7 @@
           "description": "Specify the size of the overflow menu",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6688,6 +7189,7 @@
           "type": "\"top\" | \"bottom\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6698,6 +7200,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6708,6 +7211,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6718,6 +7222,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6727,6 +7232,7 @@
           "description": "Specify the menu options class",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6736,6 +7242,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6745,6 +7252,7 @@
           "description": "Specify the icon class",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6755,6 +7263,7 @@
           "type": "string",
           "value": "\"Open and close list of options\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6765,6 +7274,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6775,6 +7285,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6785,6 +7296,7 @@
           "type": "null | HTMLUListElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -6824,6 +7336,7 @@
           "type": "string",
           "value": "\"Provide text\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6834,6 +7347,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6844,6 +7358,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6854,6 +7369,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6864,6 +7380,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6874,6 +7391,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6884,6 +7402,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6894,6 +7413,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6904,6 +7424,7 @@
           "type": "null | HTMLAnchorElement | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -6934,6 +7455,7 @@
           "type": "number",
           "value": "1",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -6944,6 +7466,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6954,6 +7477,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6964,6 +7488,7 @@
           "type": "string",
           "value": "\"Next page\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6974,6 +7499,7 @@
           "type": "string",
           "value": "\"Previous page\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6984,6 +7510,7 @@
           "type": "string",
           "value": "\"Items per page:\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -6994,6 +7521,7 @@
           "type": "(min: number, max: number) => string",
           "value": "(min, max) => `${min}–${max} items`",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7004,6 +7532,7 @@
           "type": "(min: number, max: number, total: number) => string",
           "value": "(min, max, total) =>     `${min}–${max} of ${total} items`",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7014,6 +7543,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7024,6 +7554,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7034,6 +7565,7 @@
           "type": "number",
           "value": "10",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7044,6 +7576,7 @@
           "type": "number[]",
           "value": "[10]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7054,6 +7587,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7064,6 +7598,7 @@
           "type": "(page: number) => string",
           "value": "(page) => `page ${page}`",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7074,6 +7609,7 @@
           "type": "(current: number, total: number) => string",
           "value": "(current, total) =>     `of ${total} page${total === 1 ? \"\" : \"s\"}`",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7084,6 +7620,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -7120,6 +7657,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7130,6 +7668,7 @@
           "type": "number",
           "value": "10",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7140,6 +7679,7 @@
           "type": "number",
           "value": "10",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7150,6 +7690,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7160,6 +7701,7 @@
           "type": "string",
           "value": "\"Next page\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7170,6 +7712,7 @@
           "type": "string",
           "value": "\"Previous page\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -7219,6 +7762,7 @@
           "description": "Set the size of the input",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7229,6 +7773,7 @@
           "type": "number | string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7239,6 +7784,7 @@
           "type": "\"text\" | \"password\"",
           "value": "\"password\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7249,6 +7795,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7259,6 +7806,7 @@
           "type": "string",
           "value": "\"Hide password\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7269,6 +7817,7 @@
           "type": "string",
           "value": "\"Show password\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7279,6 +7828,7 @@
           "type": "\"start\" | \"center\" | \"end\"",
           "value": "\"center\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7289,6 +7839,7 @@
           "type": "\"top\" | \"right\" | \"bottom\" | \"left\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7299,6 +7850,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7309,6 +7861,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7319,6 +7872,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7329,6 +7883,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7339,6 +7894,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7349,6 +7905,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7359,6 +7916,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7369,6 +7927,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7379,6 +7938,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7389,6 +7949,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7399,6 +7960,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7408,6 +7970,7 @@
           "description": "Specify a name attribute for the input",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7418,6 +7981,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -7456,6 +8020,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7466,6 +8031,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7476,6 +8042,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7486,6 +8053,7 @@
           "type": "\"top\" | \"top-left\" | \"top-right\" | \"bottom\" | \"bottom-left\" | \"bottom-right\" | \"left\" | \"left-bottom\" | \"left-top\" | \"right\" | \"right-bottom\" | \"right-top\"",
           "value": "\"top\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7496,6 +8064,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7506,6 +8075,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7516,6 +8086,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -7535,6 +8106,7 @@
           "description": "Specify the current value",
           "type": "number",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7545,6 +8117,7 @@
           "type": "number",
           "value": "100",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7555,6 +8128,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7565,6 +8139,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7575,6 +8150,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7585,6 +8161,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -7612,6 +8189,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7622,6 +8200,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7632,6 +8211,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7642,6 +8222,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -7668,6 +8249,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7678,6 +8260,7 @@
           "type": "number",
           "value": "4",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -7703,6 +8286,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7713,6 +8297,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7723,6 +8308,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7733,6 +8319,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7743,6 +8330,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7753,6 +8341,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7763,6 +8352,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7773,6 +8363,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -7806,6 +8397,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7816,6 +8408,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7826,6 +8419,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7836,6 +8430,7 @@
           "type": "\"right\" | \"left\"",
           "value": "\"right\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7846,6 +8441,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7856,6 +8452,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7866,6 +8463,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7876,6 +8474,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7886,6 +8485,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -7912,6 +8512,7 @@
           "description": "Set the selected radio button value",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -7922,6 +8523,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7932,6 +8534,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7942,6 +8545,7 @@
           "type": "\"right\" | \"left\"",
           "value": "\"right\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7952,6 +8556,7 @@
           "type": "\"horizontal\" | \"vertical\"",
           "value": "\"horizontal\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -7961,6 +8566,7 @@
           "description": "Set an id for the container div element",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8009,6 +8615,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -8019,6 +8626,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8029,6 +8637,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8039,6 +8648,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8049,6 +8659,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8059,6 +8670,7 @@
           "type": "string",
           "value": "\"Tile checkmark\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8069,6 +8681,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8079,6 +8692,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8106,6 +8720,7 @@
           "type": "Array<RecursiveListNode & { children?: RecursiveListNode[]; }>",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8116,6 +8731,7 @@
           "type": "\"unordered\" | \"ordered\" | \"ordered-native\"",
           "value": "\"unordered\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8142,6 +8758,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8152,6 +8769,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8162,6 +8780,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8172,6 +8791,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8182,6 +8802,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8192,6 +8813,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8202,6 +8824,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8227,6 +8850,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8237,6 +8861,7 @@
           "type": "\"sm\" | \"lg\" | \"xl\"",
           "value": "\"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8247,6 +8872,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8257,6 +8883,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8267,6 +8894,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8277,6 +8905,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8287,6 +8916,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8297,6 +8927,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -8307,6 +8938,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -8317,6 +8949,7 @@
           "type": "string",
           "value": "\"text\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8327,6 +8960,7 @@
           "type": "string",
           "value": "\"Search...\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8337,6 +8971,7 @@
           "type": "\"on\" | \"off\"",
           "value": "\"off\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8347,6 +8982,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8357,6 +8993,7 @@
           "type": "string",
           "value": "\"Clear search input\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8367,6 +9004,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8376,6 +9014,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8386,6 +9025,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8396,6 +9036,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -8448,6 +9089,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8458,6 +9100,7 @@
           "type": "\"sm\" | \"lg\" | \"xl\"",
           "value": "\"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8482,6 +9125,7 @@
           "description": "Specify the selected item value",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -8491,6 +9135,7 @@
           "description": "Set the size of the select input",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8501,6 +9146,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8511,6 +9157,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8521,6 +9168,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8531,6 +9179,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8540,6 +9189,7 @@
           "description": "Specify a name attribute for the select element",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8550,6 +9200,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8560,6 +9211,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8570,6 +9222,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8580,6 +9233,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8590,6 +9244,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8600,6 +9255,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8610,6 +9266,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8620,6 +9277,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8630,6 +9288,7 @@
           "type": "null | HTMLSelectElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -8661,6 +9320,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8671,6 +9331,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8681,6 +9342,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8691,6 +9353,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8710,6 +9373,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8720,6 +9384,7 @@
           "type": "string",
           "value": "\"Provide label\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8740,6 +9405,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8765,6 +9431,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -8775,6 +9442,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8785,6 +9453,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8795,6 +9464,7 @@
           "type": "string",
           "value": "\"title\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8805,6 +9475,7 @@
           "type": "string",
           "value": "\"value\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8815,6 +9486,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8825,6 +9497,7 @@
           "type": "string",
           "value": "\"Tile checkmark\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8835,6 +9508,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8845,6 +9519,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8855,6 +9530,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -8881,6 +9557,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8891,6 +9568,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8900,6 +9578,7 @@
           "description": "Specify the ARIA label for the nav",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8910,6 +9589,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -8920,6 +9600,7 @@
           "type": "number",
           "value": "1056",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -8961,6 +9642,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8970,6 +9652,7 @@
           "description": "Specify the `href` attribute",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8979,6 +9662,7 @@
           "description": "Specify the text",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8988,6 +9672,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -8998,6 +9683,7 @@
           "type": "null | HTMLAnchorElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -9018,6 +9704,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -9027,6 +9714,7 @@
           "description": "Specify the text",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9036,6 +9724,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9046,6 +9735,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -9066,6 +9756,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9075,6 +9766,7 @@
           "description": "Specify the `href` attribute",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9084,6 +9776,7 @@
           "description": "Specify the item text",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9094,6 +9787,7 @@
           "type": "null | HTMLAnchorElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -9135,6 +9829,7 @@
           "type": "number",
           "value": "3",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9145,6 +9840,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9155,6 +9851,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9165,6 +9862,7 @@
           "type": "string",
           "value": "\"100%\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9190,6 +9888,7 @@
           "type": "string",
           "value": "\"#main-content\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9200,6 +9899,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9227,6 +9927,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -9237,6 +9938,7 @@
           "type": "number",
           "value": "100",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9247,6 +9949,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9257,6 +9960,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9267,6 +9971,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9277,6 +9982,7 @@
           "type": "number",
           "value": "1",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9287,6 +9993,7 @@
           "type": "number",
           "value": "4",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9297,6 +10004,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9307,6 +10015,7 @@
           "type": "string",
           "value": "\"number\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9317,6 +10026,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9327,6 +10037,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9337,6 +10048,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9347,6 +10059,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9357,6 +10070,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9367,6 +10081,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9377,6 +10092,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9387,6 +10103,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -9420,6 +10137,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9444,6 +10162,7 @@
           "description": "Specify the selected structured list row value",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -9454,6 +10173,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9464,6 +10184,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9474,6 +10195,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9484,6 +10206,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9524,6 +10247,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9534,6 +10258,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9573,6 +10298,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -9583,6 +10309,7 @@
           "type": "string",
           "value": "\"title\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9593,6 +10320,7 @@
           "type": "string",
           "value": "\"value\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9603,6 +10331,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9613,6 +10342,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9623,6 +10353,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -9643,6 +10374,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9653,6 +10385,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9663,6 +10396,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9689,6 +10423,7 @@
           "type": "number",
           "value": "5",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9699,6 +10434,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9724,6 +10460,7 @@
           "type": "string",
           "value": "\"Provide text\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9734,6 +10471,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -9744,6 +10482,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9754,6 +10493,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9764,6 +10504,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -9797,6 +10538,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9807,6 +10549,7 @@
           "type": "string",
           "value": "\"#\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9817,6 +10560,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9827,6 +10571,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9837,6 +10582,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9847,6 +10593,7 @@
           "type": "null | HTMLAnchorElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -9879,6 +10626,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9898,6 +10646,7 @@
           "description": "Set the size of the table",
           "type": "\"compact\" | \"short\" | \"medium\" | \"tall\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9908,6 +10657,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9918,6 +10668,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9928,6 +10679,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9938,6 +10690,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -9948,6 +10701,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -9991,6 +10745,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10001,6 +10756,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10011,6 +10767,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10045,6 +10802,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10055,6 +10813,7 @@
           "type": "string",
           "value": "\"col\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10065,6 +10824,7 @@
           "type": "() => string",
           "value": "() => \"\"",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10075,6 +10835,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10114,6 +10875,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -10124,6 +10886,7 @@
           "type": "\"default\" | \"container\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10134,6 +10897,7 @@
           "type": "string",
           "value": "\"Show menu options\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10144,6 +10908,7 @@
           "type": "string",
           "value": "\"#\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10171,6 +10936,7 @@
           "type": "number",
           "value": "4",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10181,6 +10947,7 @@
           "type": "\"default\" | \"container\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10205,6 +10972,7 @@
           "description": "Specify the type of tag",
           "type": "\"red\" | \"magenta\" | \"purple\" | \"blue\" | \"cyan\" | \"teal\" | \"green\" | \"gray\" | \"cool-gray\" | \"warm-gray\" | \"high-contrast\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10214,6 +10982,7 @@
           "type": "\"sm\" | \"default\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10224,6 +10993,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10234,6 +11004,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10244,6 +11015,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10254,6 +11026,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10264,6 +11037,7 @@
           "type": "string",
           "value": "\"Clear filter\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10273,6 +11047,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10283,6 +11058,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10314,6 +11090,7 @@
           "type": "\"sm\" | \"default\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10339,6 +11116,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -10349,6 +11127,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10359,6 +11138,7 @@
           "type": "number",
           "value": "50",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10369,6 +11149,7 @@
           "type": "number",
           "value": "4",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10379,6 +11160,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10389,6 +11171,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10399,6 +11182,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10409,6 +11193,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10419,6 +11204,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10429,6 +11215,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10439,6 +11226,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10449,6 +11237,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10458,6 +11247,7 @@
           "description": "Specify a name attribute for the input",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10468,6 +11258,7 @@
           "type": "null | HTMLTextAreaElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -10506,6 +11297,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10530,6 +11322,7 @@
           "description": "Set the size of the input",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10540,6 +11333,7 @@
           "type": "number | string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -10550,6 +11344,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10560,6 +11355,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10570,6 +11366,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10580,6 +11377,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10590,6 +11388,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10600,6 +11399,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10609,6 +11409,7 @@
           "description": "Specify a name attribute for the input",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10619,6 +11420,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10629,6 +11431,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10639,6 +11442,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10649,6 +11453,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10659,6 +11464,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10669,6 +11475,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10679,6 +11486,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -10689,6 +11497,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10699,6 +11508,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10709,6 +11519,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10747,6 +11558,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10772,6 +11584,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10796,6 +11609,7 @@
           "description": "Specify the selected tile value",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -10806,6 +11620,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10816,6 +11631,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -10835,6 +11651,7 @@
           "description": "Specify the size of the input",
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10845,6 +11662,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -10855,6 +11673,7 @@
           "type": "string",
           "value": "\"text\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10865,6 +11684,7 @@
           "type": "string",
           "value": "\"hh:mm\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10875,6 +11695,7 @@
           "type": "string",
           "value": "\"(1[012]|[1-9]):[0-5][0-9](\\\\s)?\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10885,6 +11706,7 @@
           "type": "number",
           "value": "5",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10895,6 +11717,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10905,6 +11728,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10915,6 +11739,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10925,6 +11750,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10935,6 +11761,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10945,6 +11772,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10955,6 +11783,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10964,6 +11793,7 @@
           "description": "Specify a name attribute for the input",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -10974,6 +11804,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -11013,6 +11844,7 @@
           "type": "number | string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -11023,6 +11855,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11033,6 +11866,7 @@
           "type": "string",
           "value": "\"Open list of options\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11043,6 +11877,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11052,6 +11887,7 @@
           "type": "boolean",
           "value": "true",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11062,6 +11898,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11071,6 +11908,7 @@
           "description": "Specify a name attribute for the select element",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11081,6 +11919,7 @@
           "type": "null | HTMLSelectElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -11114,6 +11953,7 @@
           "type": "\"error\" | \"info\" | \"info-square\" | \"success\" | \"warning\" | \"warning-alt\"",
           "value": "\"error\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11124,6 +11964,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11134,6 +11975,7 @@
           "type": "number",
           "value": "0",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11144,6 +11986,7 @@
           "type": "string",
           "value": "\"alert\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11154,6 +11997,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11164,6 +12008,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11174,6 +12019,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11184,6 +12030,7 @@
           "type": "string",
           "value": "\"Closes notification\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11194,6 +12041,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -11224,6 +12072,7 @@
           "type": "\"default\" | \"sm\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11234,6 +12083,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -11244,6 +12094,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11254,6 +12105,7 @@
           "type": "string",
           "value": "\"Off\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11264,6 +12116,7 @@
           "type": "string",
           "value": "\"On\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11274,6 +12127,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11284,6 +12138,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11293,6 +12148,7 @@
           "description": "Specify a name attribute for the checkbox input",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -11334,6 +12190,7 @@
           "type": "\"default\" | \"sm\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11344,6 +12201,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11354,6 +12212,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -11386,6 +12245,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -11396,6 +12256,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11406,6 +12267,7 @@
           "type": "string",
           "value": "\"Off\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11416,6 +12278,7 @@
           "type": "string",
           "value": "\"On\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11426,6 +12289,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11436,6 +12300,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11445,6 +12310,7 @@
           "description": "Specify a name attribute for the checkbox input",
           "type": "string",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -11474,6 +12340,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11484,6 +12351,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -11509,6 +12377,7 @@
           "type": "\"sm\" | \"default\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -11529,6 +12398,7 @@
           "type": "(totalSelected: number) => string",
           "value": "(totalSelected) =>     `${totalSelected} item${totalSelected === 1 ? \"\" : \"s\"} selected`",
           "isFunction": true,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -11590,6 +12460,7 @@
           "type": "number | string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -11600,6 +12471,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -11610,6 +12482,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11620,6 +12493,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11630,6 +12504,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11640,6 +12515,7 @@
           "type": "null | HTMLInputElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -11666,6 +12542,7 @@
           "type": "\"start\" | \"center\" | \"end\"",
           "value": "\"center\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11676,6 +12553,7 @@
           "type": "\"top\" | \"right\" | \"bottom\" | \"left\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11686,6 +12564,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -11696,6 +12575,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11705,6 +12585,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render for the tooltip button\nIcon size must be 16px (e.g., `Add16`, `Task16`)",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11715,6 +12596,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11725,6 +12607,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11735,6 +12618,7 @@
           "type": "string",
           "value": "\"0\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11745,6 +12629,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11755,6 +12640,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11765,6 +12651,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11775,6 +12662,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -11785,6 +12673,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -11795,6 +12684,7 @@
           "type": "null | HTMLDivElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -11832,6 +12722,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11842,6 +12733,7 @@
           "type": "\"start\" | \"center\" | \"end\"",
           "value": "\"center\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11852,6 +12744,7 @@
           "type": "\"top\" | \"bottom\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11862,6 +12755,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11872,6 +12766,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -11906,6 +12801,7 @@
           "type": "string",
           "value": "\"a[href], button:not([disabled])\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -11925,6 +12821,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11934,6 +12831,7 @@
           "description": "Specify the icon from `carbon-icons-svelte` to render",
           "type": "typeof import(\"carbon-icons-svelte\").CarbonIcon",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11944,6 +12842,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11954,6 +12853,7 @@
           "type": "\"start\" | \"center\" | \"end\"",
           "value": "\"center\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11964,6 +12864,7 @@
           "type": "\"top\" | \"right\" | \"bottom\" | \"left\"",
           "value": "\"bottom\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11974,6 +12875,7 @@
           "type": "string",
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -11984,6 +12886,7 @@
           "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         }
@@ -12023,6 +12926,7 @@
           "type": "Array<TreeNode & { children?: TreeNode[] }>",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -12033,6 +12937,7 @@
           "type": "TreeNodeId",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -12043,6 +12948,7 @@
           "type": "TreeNodeId[]",
           "value": "[]",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": true
         },
@@ -12053,6 +12959,7 @@
           "type": "\"default\" | \"compact\"",
           "value": "\"default\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -12063,6 +12970,7 @@
           "type": "string",
           "value": "\"\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -12073,6 +12981,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -12127,6 +13036,7 @@
           "type": "\"end\" | \"front\"",
           "value": "\"end\"",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }
@@ -12147,6 +13057,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         },
@@ -12157,6 +13068,7 @@
           "type": "boolean",
           "value": "false",
           "isFunction": false,
+          "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
         }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.32.6",
-    "sveld": "^0.7.0",
+    "sveld": "0.8.1",
     "svelte": "^3.32.1",
     "svelte-check": "^1.1.32",
     "typescript": "^4.1.3"

--- a/tests/Breakpoint.test.svelte
+++ b/tests/Breakpoint.test.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Breakpoint } from "../types";
+  import { BreakpointSize } from "../types/Breakpoint/Breakpoint";
 
-  let size;
+  let size: BreakpointSize;
 </script>
 
 <Breakpoint

--- a/tests/CodeSnippet.test.svelte
+++ b/tests/CodeSnippet.test.svelte
@@ -35,7 +35,7 @@ export function subtract(a: number, b: number) {
   hideCloseButton
 />
 
-<CodeSnippet copy="{(text) => {}}"
+<CodeSnippet copy="{(text) => text}"
   >yarn add -D carbon-components-svelte</CodeSnippet
 >
 

--- a/tests/CopyButton.test.svelte
+++ b/tests/CopyButton.test.svelte
@@ -6,6 +6,6 @@
   text="text"
   on:click
   on:copy
-  copy="{(text) => {}}"
+  copy="{(text) => text}"
   feedback="Copied to clipboard"
 />

--- a/tests/LocalStorage.test.svelte
+++ b/tests/LocalStorage.test.svelte
@@ -4,6 +4,9 @@
   let storage: LocalStorage;
   let toggled = false;
   let events = [];
+
+  $: if (storage) storage.clearItem();
+  $: if (storage) storage.clearAll();
 </script>
 
 <LocalStorage

--- a/tests/Modal.test.svelte
+++ b/tests/Modal.test.svelte
@@ -12,7 +12,10 @@
   primaryButtonText="Confirm"
   secondaryButtons="{[{ text: 'Cancel' }, { text: 'Duplicate' }]}"
   secondaryButtonText="Cancel"
-  on:click:button--secondary="{({ detail }) => (open = false)}"
+  on:click:button--secondary="{({ detail }) => {
+    console.log(detail);
+    open = false;
+  }}"
   on:open
   on:close
   on:submit

--- a/types/LocalStorage/LocalStorage.d.ts
+++ b/types/LocalStorage/LocalStorage.d.ts
@@ -13,18 +13,6 @@ export interface LocalStorageProps {
    * @default ""
    */
   value?: any;
-
-  /**
-   * Remove the persisted key value from the browser's local storage
-   * @default () => { localStorage.removeItem(key); }
-   */
-  clearItem?: () => void;
-
-  /**
-   * Clear all key values from the browser's local storage
-   * @default () => { localStorage.clear(); }
-   */
-  clearAll?: () => void;
 }
 
 export default class LocalStorage extends SvelteComponentTyped<
@@ -34,4 +22,14 @@ export default class LocalStorage extends SvelteComponentTyped<
     update: CustomEvent<{ prevValue: any; value: any }>;
   },
   {}
-> {}
+> {
+  /**
+   * Remove the persisted key value from the browser's local storage
+   */
+  clearItem: () => void;
+
+  /**
+   * Clear all key values from the browser's local storage
+   */
+  clearAll: () => void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,10 +2383,10 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-sveld@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.7.0.tgz#379ecb92e42216cca11f7d7beecef6587c8f2b16"
-  integrity sha512-M022X3vjs6EVunPSC/oubO3br8vwcBZXYTdglGrydNCSTY5JewE+tY6Y+z8TaYeFt7PtEc6uVz1vzBIUqcrpyw==
+sveld@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.8.1.tgz#9fcd23efdb350500337ac1ec041647b0a8dac49d"
+  integrity sha512-OtOEYDNFcjL9tmTvIJ+Iwt9nwN9NfClf5iP0bHGQRZzfSIlxY1lnl81cdMPgNz54ef5Sdibw7g4ham/MK+Spzw==
   dependencies:
     "@rollup/plugin-node-resolve" "^11.0.1"
     acorn "^8.0.4"
@@ -2397,6 +2397,8 @@ sveld@^0.7.0:
     rollup "^2.36.0"
     rollup-plugin-svelte "^7.0.0"
     svelte "^3.31.2"
+    svelte-preprocess "^4.7.3"
+    typescript "^4.1.3"
 
 svelte-check@^1.1.32:
   version "1.1.32"
@@ -2416,6 +2418,16 @@ svelte-preprocess@^4.0.0:
   version "4.5.2"
   resolved "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.5.2.tgz#37976d1e0d866eb382411d486f7468d2275087e9"
   integrity sha512-ClUX5NecnGBwI+nJnnBvKKy0XutCq5uHTIKe6cPhpvuOj9AAnyvef9wOZAE93yr85OKPutGCNIJa/X1TrJ7O0Q==
+  dependencies:
+    "@types/pug" "^2.0.4"
+    "@types/sass" "^1.16.0"
+    detect-indent "^6.0.0"
+    strip-indent "^3.0.0"
+
+svelte-preprocess@^4.7.3:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.7.4.tgz#e4d5208ab25c2aaaf19e837f7d7bbf7930e61d2b"
+  integrity sha512-mDAmaltQl6e5zU2VEtoWEf7eLTfuOTGr9zt+BpA3AGHo8MIhKiNSPE9OLTCTOMgj0vj/uL9QBbaNmpG4G1CgIA==
   dependencies:
     "@types/pug" "^2.0.4"
     "@types/sass" "^1.16.0"


### PR DESCRIPTION
**Fixes**

- upgrade `sveld` to v0.8.1 to type functional declarations as accessors, not props

For example, `LocalStorage` exports `clearItem` and `clearAll`, which should be accessible on the component instance.

```svelte
<script lang="ts">
  import { LocalStorage } from "carbon-components-svelte";

  let storage: LocalStorage;
  let toggled = false;

  $: if (storage) storage.clearItem();
  $: if (storage) storage.clearAll();
</script>

<LocalStorage
  bind:this="{storage}"
  bind:value="{toggled}"
/>

```