### PR TITLE
fix(types): upgrade sveld and type constant props as accessors

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.32.6",
-    "sveld": "0.8.1",
+    "sveld": "^0.8.2",
     "svelte": "^3.32.1",
     "svelte-check": "^1.1.32",
     "typescript": "^4.1.3"

--- a/types/Breakpoint/Breakpoint.d.ts
+++ b/types/Breakpoint/Breakpoint.d.ts
@@ -16,13 +16,6 @@ export interface BreakpointProps {
    * @default { sm: false, md: false, lg: false, xlg: false, max: false, }
    */
   sizes?: Record<BreakpointSize, boolean>;
-
-  /**
-   * Reference the Carbon grid breakpoints
-   * @constant
-   * @default { sm: 320, md: 672, lg: 1056, xlg: 1312, max: 1584, }
-   */
-  breakpoints?: { sm: 320; md: 672; lg: 1056; xlg: 1312; max: 1584 };
 }
 
 export default class Breakpoint extends SvelteComponentTyped<
@@ -34,4 +27,11 @@ export default class Breakpoint extends SvelteComponentTyped<
     }>;
   },
   { default: { size: BreakpointSize; sizes: Record<BreakpointSize, boolean> } }
-> {}
+> {
+  /**
+   * Reference the Carbon grid breakpoints
+   * @constant
+   * @default { sm: 320, md: 672, lg: 1056, xlg: 1312, max: 1584, }
+   */
+  breakpoints: Record<BreakpointSize, BreakpointValue>;
+}

--- a/types/FileUploader/FileUploader.d.ts
+++ b/types/FileUploader/FileUploader.d.ts
@@ -28,13 +28,6 @@ export interface FileUploaderProps
   multiple?: boolean;
 
   /**
-   * Override the default behavior of clearing the array of uploaded files
-   * @constant
-   * @default () => { files = []; }
-   */
-  clearFiles?: () => void;
-
-  /**
    * Specify the label description
    * @default ""
    */
@@ -84,4 +77,11 @@ export default class FileUploader extends SvelteComponentTyped<
     keydown: WindowEventMap["keydown"];
   },
   {}
-> {}
+> {
+  /**
+   * Override the default behavior of clearing the array of uploaded files
+   * @constant
+   * @default () => { files = []; }
+   */
+  clearFiles: () => void;
+}

--- a/types/ImageLoader/ImageLoader.d.ts
+++ b/types/ImageLoader/ImageLoader.d.ts
@@ -44,17 +44,17 @@ export interface ImageLoaderProps
    * @default false
    */
   fadeIn?: boolean;
-
-  /**
-   * Method invoked to load the image provided a `src` value
-   * @constant
-   * @default (url) => { if (image != null) image = null; loaded = false; error = false; image = new Image(); image.src = url || src; image.onload = () => (loaded = true); image.onerror = () => (error = true); }
-   */
-  loadImage?: (url?: string) => void;
 }
 
 export default class ImageLoader extends SvelteComponentTyped<
   ImageLoaderProps,
   { load: CustomEvent<any>; error: CustomEvent<any> },
   { error: {}; loading: {} }
-> {}
+> {
+  /**
+   * Method invoked to load the image provided a `src` value
+   * @constant
+   * @default (url) => { if (image != null) image = null; loaded = false; error = false; image = new Image(); image.src = url || src; image.onload = () => (loaded = true); image.onerror = () => (error = true); }
+   */
+  loadImage: (url?: string) => void;
+}

--- a/types/ListBox/ListBoxField.d.ts
+++ b/types/ListBox/ListBoxField.d.ts
@@ -24,13 +24,6 @@ export interface ListBoxFieldProps
   tabindex?: string;
 
   /**
-   * Default translation ids
-   * @constant
-   * @default { close: "close", open: "open" }
-   */
-  translationIds?: { close: "close"; open: "open" };
-
-  /**
    * Override the default translation ids
    * @default (id) => defaultTranslations[id]
    */
@@ -61,4 +54,11 @@ export default class ListBoxField extends SvelteComponentTyped<
     blur: WindowEventMap["blur"];
   },
   { default: {} }
-> {}
+> {
+  /**
+   * Default translation ids
+   * @constant
+   * @default { close: "close", open: "open" }
+   */
+  translationIds: { close: "close"; open: "open" };
+}

--- a/types/ListBox/ListBoxMenuIcon.d.ts
+++ b/types/ListBox/ListBoxMenuIcon.d.ts
@@ -12,13 +12,6 @@ export interface ListBoxMenuIconProps
   open?: boolean;
 
   /**
-   * Default translation ids
-   * @constant
-   * @default { close: "close", open: "open" }
-   */
-  translationIds?: { close: "close"; open: "open" };
-
-  /**
    * Override the default translation ids
    * @default (id) => defaultTranslations[id]
    */
@@ -29,4 +22,11 @@ export default class ListBoxMenuIcon extends SvelteComponentTyped<
   ListBoxMenuIconProps,
   { click: WindowEventMap["click"] },
   {}
-> {}
+> {
+  /**
+   * Default translation ids
+   * @constant
+   * @default { close: "close", open: "open" }
+   */
+  translationIds: { close: "close"; open: "open" };
+}

--- a/types/ListBox/ListBoxSelection.d.ts
+++ b/types/ListBox/ListBoxSelection.d.ts
@@ -17,13 +17,6 @@ export interface ListBoxSelectionProps
   disabled?: boolean;
 
   /**
-   * Default translation ids
-   * @constant
-   * @default { clearAll: "clearAll", clearSelection: "clearSelection", }
-   */
-  translationIds?: { clearAll: "clearAll"; clearSelection: "clearSelection" };
-
-  /**
    * Override the default translation ids
    * @default (id) => defaultTranslations[id]
    */
@@ -40,4 +33,11 @@ export default class ListBoxSelection extends SvelteComponentTyped<
   ListBoxSelectionProps,
   { clear: CustomEvent<any> },
   {}
-> {}
+> {
+  /**
+   * Default translation ids
+   * @constant
+   * @default { clearAll: "clearAll", clearSelection: "clearSelection", }
+   */
+  translationIds: { clearAll: "clearAll"; clearSelection: "clearSelection" };
+}

--- a/types/LocalStorage/LocalStorage.d.ts
+++ b/types/LocalStorage/LocalStorage.d.ts
@@ -25,11 +25,13 @@ export default class LocalStorage extends SvelteComponentTyped<
 > {
   /**
    * Remove the persisted key value from the browser's local storage
+   * @default () => { localStorage.removeItem(key); }
    */
   clearItem: () => void;
 
   /**
    * Clear all key values from the browser's local storage
+   * @default () => { localStorage.clear(); }
    */
   clearAll: () => void;
 }

--- a/types/NumberInput/NumberInput.d.ts
+++ b/types/NumberInput/NumberInput.d.ts
@@ -123,13 +123,6 @@ export interface NumberInputProps
   translateWithId?: (id: NumberInputTranslationId) => string;
 
   /**
-   * Default translation ids
-   * @constant
-   * @default { increment: "increment", decrement: "decrement", }
-   */
-  translationIds?: { increment: "increment"; decrement: "decrement" };
-
-  /**
    * Set an id for the input element
    * @default "ccs-" + Math.random().toString(36)
    */
@@ -158,4 +151,11 @@ export default class NumberInput extends SvelteComponentTyped<
     input: WindowEventMap["input"];
   },
   { label: {} }
-> {}
+> {
+  /**
+   * Default translation ids
+   * @constant
+   * @default { increment: "increment", decrement: "decrement", }
+   */
+  translationIds: { increment: "increment"; decrement: "decrement" };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,10 +2383,10 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-sveld@0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.8.1.tgz#9fcd23efdb350500337ac1ec041647b0a8dac49d"
-  integrity sha512-OtOEYDNFcjL9tmTvIJ+Iwt9nwN9NfClf5iP0bHGQRZzfSIlxY1lnl81cdMPgNz54ef5Sdibw7g4ham/MK+Spzw==
+sveld@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.8.2.tgz#979324cb058846ca686f563012e4615e35093094"
+  integrity sha512-oMv33rOc1jr4sV0gBozx4HJgDb6XAqelLgZn6ME4RgvFnK5mPWR/5On1LfMvFPXZVZMWac0id8VJVJMZVYPcNA==
   dependencies:
     "@rollup/plugin-node-resolve" "^11.0.1"
     acorn "^8.0.4"


### PR DESCRIPTION
**Fixes**

- type constant props in TypeScript definitions as accessors in the `SvelteComponentTyped` interface

Example:

```diff
/// <reference types="svelte" />
import { SvelteComponentTyped } from "svelte";

export type BreakpointSize = "sm" | "md" | "lg" | "xlg" | "max";

export type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;

export interface BreakpointProps {
  /**
   * Determine the current Carbon grid breakpoint size
   */
  size?: BreakpointSize;

  /**
   * Carbon grid sizes as an object
   * @default { sm: false, md: false, lg: false, xlg: false, max: false, }
   */
  sizes?: Record<BreakpointSize, boolean>;

-  /**
-   * Reference the Carbon grid breakpoints
-   * @constant
-   * @default { sm: 320, md: 672, lg: 1056, xlg: 1312, max: 1584, }
-   */
-  breakpoints: Record<BreakpointSize, BreakpointValue>;
}

export default class Breakpoint extends SvelteComponentTyped<
  BreakpointProps,
  {
    match: CustomEvent<{
      size: BreakpointSize;
      breakpointValue: BreakpointValue;
    }>;
  },
  { default: { size: BreakpointSize; sizes: Record<BreakpointSize, boolean> } }
> {
+  /**
+   * Reference the Carbon grid breakpoints
+   * @constant
+   * @default { sm: 320, md: 672, lg: 1056, xlg: 1312, max: 1584, }
+   */
+  breakpoints: Record<BreakpointSize, BreakpointValue>;
}

```