### PR TITLE
fix: close overlays on window click

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -152,12 +152,13 @@
   $: value = inputValue;
 </script>
 
-<svelte:body
+<svelte:window
   on:click="{({ target }) => {
     if (open && ref && !ref.contains(target)) {
       open = false;
     }
-  }}" />
+  }}"
+/>
 
 <div class:bx--list-box__wrapper="{true}">
   {#if titleText}

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -192,12 +192,13 @@
   $: if ($hasCalendar && !calendar && inputRef) initCalendar();
 </script>
 
-<svelte:body
+<svelte:window
   on:click="{({ target }) => {
     if (!calendar || !calendar.isOpen) return;
     if (datePickerRef && datePickerRef.contains(target)) return;
     if (!calendar.calendarContainer.contains(target)) calendar.close();
-  }}" />
+  }}"
+/>
 
 <div
   class:bx--form-item="{true}"

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -238,12 +238,13 @@
   $: value = inputValue;
 </script>
 
-<svelte:body
+<svelte:window
   on:click="{({ target }) => {
     if (open && multiSelectRef && !multiSelectRef.contains(target)) {
       open = false;
     }
-  }}" />
+  }}"
+/>
 
 <div
   bind:this="{multiSelectRef}"

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -165,13 +165,14 @@
   {@html styles}
 </svelte:head>
 
-<svelte:body
+<svelte:window
   on:click="{({ target }) => {
     if (buttonRef && buttonRef.contains(target)) return;
     if (menuRef && !menuRef.contains(target)) {
       open = false;
     }
-  }}" />
+  }}"
+/>
 
 <button
   bind:this="{buttonRef}"

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -116,12 +116,13 @@
   }
 </script>
 
-<svelte:body
+<svelte:window
   on:mousemove="{move}"
   on:touchmove="{move}"
   on:mouseup="{stopHolding}"
   on:touchend="{stopHolding}"
-  on:touchcancel="{stopHolding}" />
+  on:touchcancel="{stopHolding}"
+/>
 
 <div
   class:bx--form-item="{true}"

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -163,7 +163,7 @@
   };
 </script>
 
-<svelte:body
+<svelte:window
   on:mousedown="{({ target }) => {
     if (open && target.contains(refTooltip)) {
       if (refIcon) {
@@ -174,7 +174,8 @@
 
       open = false;
     }
-  }}" />
+  }}"
+/>
 
 <div
   {...$$restProps}

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -31,10 +31,11 @@
   }
 </script>
 
-<svelte:body
+<svelte:window
   on:keydown="{({ key }) => {
     if (key === 'Escape') hide();
-  }}" />
+  }}"
+/>
 
 <span
   class:bx--tooltip--definition="{true}"

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -35,12 +35,13 @@
   let hidden = false;
 </script>
 
-<svelte:body
+<svelte:window
   on:keydown="{({ key }) => {
     if (key === 'Escape') {
       hidden = true;
     }
-  }}" />
+  }}"
+/>
 
 <button
   bind:this="{ref}"


### PR DESCRIPTION
Replace all occurrences of `svelte:body` with `svelte:window` to resolve the issue described in #315.

All occurrences listed in [this comment](https://github.com/IBM/carbon-components-svelte/issues/315#issuecomment-705669503) were replaced, except for `Dropdown/Dropdown.svelte`, as it was already replaced.