### PR TITLE
Fix a11y-mouse-events warning, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Design systems facilitate design and development through reuse, consistency, and
 
 The Carbon Svelte portfolio also includes:
 
-- **[Carbon Icons Svelte](https://github.com/IBM/carbon-icons-svelte)**: 6000+ Carbon icons as Svelte components
+- **[Carbon Icons Svelte](https://github.com/IBM/carbon-icons-svelte)**: 7000+ Carbon icons as Svelte components
 - **[Carbon Pictograms Svelte](https://github.com/IBM/carbon-pictograms-svelte)**: 700+ Carbon pictograms as Svelte components
 - **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 20+ charts, powered by d3
 - **[Carbon Preprocess Svelte](https://github.com/IBM/carbon-preprocess-svelte)**: Collection of Svelte preprocessors for Carbon

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -158,6 +158,7 @@
 
   .prose > p > .bx--link {
     font-size: inherit;
+    text-decoration: underline;
   }
 
   .prose .toc {

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -29,7 +29,17 @@
     g80: "Gray 80",
     g90: "Gray 90",
     g100: "Gray 100",
+    all: "All",
   };
+
+  const cssImportAll = `import "carbon-components-svelte/css/all.css";`;
+  const cssThemeToggle = `<script>
+  let theme = "${$theme}"; // "white" | "g10" | "g80" | "g90" | "g100"
+
+  $: document.documentElement.setAttribute("theme", theme);
+<\/script>
+`;
+
   $: cssImport = `import "carbon-components-svelte/css/${$theme}.css";`;
   $: cssCdn = `<!DOCTYPE html>
 <html>
@@ -80,11 +90,6 @@
     <Row style="margin-bottom: var(--cds-layout-02)">
       <Column>
         <h3>Installation</h3>
-        <p>
-          Install
-          <code>carbon-components-svelte</code>
-          as a development dependency in your project.
-        </p>
         <h4>Using Yarn:</h4>
         <Row noGutter>
           <CodeSnippet code="{installYarn}" />
@@ -95,7 +100,7 @@
         </Row>
       </Column>
     </Row>
-    <Row style="margin-bottom: var(--cds-layout-05)">
+    <Row style="margin-bottom: var(--cds-layout-04)">
       <Column>
         <h3>Styling</h3>
         <p>
@@ -115,8 +120,8 @@
       </Column>
     </Row>
 
-    <Row style="margin-bottom: var(--cds-layout-02)">
-      <Column xlg="{10}" noGutter>
+    <Row>
+      <Column max="{10}" xlg="{10}" noGutter>
         <Tabs>
           <Tab label="CSS StyleSheet" />
           <Tab label="CDN" />
@@ -194,7 +199,39 @@
       </Column>
     </Row>
 
-    <Row>
+    <Row style="margin-bottom: var(--cds-layout-02)">
+      <Column>
+        <h3>Dynamic theming</h3>
+        <p>Use the "all.css" StyleSheet for dynamic, client-side theming.</p>
+        <Row padding noGutter>
+          <Column>
+            <p>
+              <CodeSnippet type="single" code="{cssImportAll}" />
+            </p>
+          </Column>
+        </Row>
+        <p>
+          Programmatically switch between each of the five Carbon themes by
+          setting the "theme" attribute on the HTML element.
+        </p>
+        <Row padding noGutter>
+          <Column>
+            <p>
+              <CodeSnippet type="multi" code="{cssThemeToggle}" />
+            </p>
+          </Column>
+        </Row>
+        <p>
+          You can use the
+          <Link inline size="lg" href="/components/Theme">
+            Theme utility component
+          </Link>
+          to update the theme at runtime.
+        </p>
+      </Column>
+    </Row>
+
+    <Row style="margin-bottom: var(--cds-layout-02)">
       <Column>
         <h3>Portfolio</h3>
         <p>

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -40,6 +40,12 @@
     />
   </head>
 </html>`;
+  $: cssCdnSvelteHead = `<svelte:head>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/carbon-components-svelte/css/${$theme}.css"
+  />
+</svelte:head>`;
 </script>
 
 <Content>
@@ -144,14 +150,20 @@
                   unpkg.com
                 </OutboundLink>.
               </p>
-              <p>
-                This is best suited for rapid prototyping or if your set-up does
-                not use a CSS loader.
-              </p>
+              <p>This is best suited for rapid prototyping.</p>
+              <h5>HTML</h5>
               <Row padding noGutter>
                 <Column>
                   <p>
                     <CodeSnippet type="multi" code="{cssCdn}" />
+                  </p>
+                </Column>
+              </Row>
+              <h5>svelte:head</h5>
+              <Row padding noGutter>
+                <Column>
+                  <p>
+                    <CodeSnippet type="multi" code="{cssCdnSvelteHead}" />
                   </p>
                 </Column>
               </Row>

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -206,7 +206,7 @@
         <TileCard
           borderBottom
           title="Carbon Icons Svelte"
-          subtitle="6000+ icons"
+          subtitle="7000+ icons"
           target="_blank"
           href="https://github.com/IBM/carbon-icons-svelte"
         />

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.32.6",
     "sveld": "^0.8.2",
-    "svelte": "^3.32.1",
+    "svelte": "^3.40.1",
     "svelte-check": "^1.1.32",
     "typescript": "^4.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "publish-examples": "node scripts/publish-examples"
   },
   "dependencies": {
-    "carbon-icons-svelte": "^10.27.0",
+    "carbon-icons-svelte": "^10.36.0",
     "flatpickr": "4.6.9"
   },
   "devDependencies": {

--- a/src/Accordion/Accordion.svelte
+++ b/src/Accordion/Accordion.svelte
@@ -30,6 +30,7 @@
   setContext("Accordion", { disableItems });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if skeleton}
   <AccordionSkeleton
     {...$$restProps}

--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -34,6 +34,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <li
   class:bx--accordion__item="{true}"
   class:bx--accordion__item--active="{open}"

--- a/src/Accordion/AccordionSkeleton.svelte
+++ b/src/Accordion/AccordionSkeleton.svelte
@@ -21,6 +21,7 @@
   import SkeletonText from "../SkeletonText/SkeletonText.svelte";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <ul
   class:bx--skeleton="{true}"
   class:bx--accordion="{true}"

--- a/src/Breadcrumb/Breadcrumb.svelte
+++ b/src/Breadcrumb/Breadcrumb.svelte
@@ -10,6 +10,7 @@
   import BreadcrumbSkeleton from "./BreadcrumbSkeleton.svelte";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if skeleton}
   <BreadcrumbSkeleton
     noTrailingSlash="{noTrailingSlash}"

--- a/src/Breadcrumb/BreadcrumbItem.svelte
+++ b/src/Breadcrumb/BreadcrumbItem.svelte
@@ -19,6 +19,7 @@
   setContext("BreadcrumbItem", {});
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <li
   class:bx--breadcrumb-item="{true}"
   class:bx--breadcrumb-item--current="{isCurrentPage &&

--- a/src/Breadcrumb/BreadcrumbSkeleton.svelte
+++ b/src/Breadcrumb/BreadcrumbSkeleton.svelte
@@ -6,6 +6,7 @@
   export let count = 3;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--skeleton="{true}"
   class:bx--breadcrumb="{true}"

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -131,6 +131,7 @@
   };
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if skeleton}
   <ButtonSkeleton
     href="{href}"

--- a/src/Button/ButtonSkeleton.svelte
+++ b/src/Button/ButtonSkeleton.svelte
@@ -18,6 +18,7 @@
   export let small = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if href}
   <a
     href="{href}"

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -47,6 +47,7 @@
   $: dispatch("check", checked);
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if skeleton}
   <CheckboxSkeleton
     {...$$restProps}

--- a/src/Checkbox/CheckboxSkeleton.svelte
+++ b/src/Checkbox/CheckboxSkeleton.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   class:bx--checkbox-wrapper="{true}"

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -116,6 +116,7 @@
   }
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if skeleton}
   <CodeSnippetSkeleton
     type="{type}"

--- a/src/CodeSnippet/CodeSnippetSkeleton.svelte
+++ b/src/CodeSnippet/CodeSnippetSkeleton.svelte
@@ -6,6 +6,7 @@
   export let type = "single";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--skeleton="{true}"
   class:bx--snippet="{true}"

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -97,6 +97,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   bind:this="{ref}"
   role="presentation"

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -63,6 +63,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   role="tablist"
   class:bx--content-switcher="{true}"

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -38,6 +38,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <button
   bind:this="{ref}"
   role="tab"

--- a/src/DataTable/DataTableSkeleton.svelte
+++ b/src/DataTable/DataTableSkeleton.svelte
@@ -41,6 +41,7 @@
   );
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--skeleton="{true}"
   class:bx--data-table-container="{true}"

--- a/src/DataTable/TableCell.svelte
+++ b/src/DataTable/TableCell.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <td {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
   <slot />
 </td>

--- a/src/DataTable/TableHead.svelte
+++ b/src/DataTable/TableHead.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <thead {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
   <slot />
 </thead>

--- a/src/DataTable/TableHeader.svelte
+++ b/src/DataTable/TableHeader.svelte
@@ -27,6 +27,7 @@
   $: ariaLabel = translateWithId();
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if $tableSortable && !disableSorting}
   <th
     aria-sort="{active ? $sortHeader.sortDirection : 'none'}"

--- a/src/DataTable/TableRow.svelte
+++ b/src/DataTable/TableRow.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <tr {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
   <slot />
 </tr>

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -200,6 +200,7 @@
   }}"
 />
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/DatePicker/DatePickerSkeleton.svelte
+++ b/src/DatePicker/DatePickerSkeleton.svelte
@@ -6,6 +6,7 @@
   export let id = "ccs-" + Math.random().toString(36);
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Dropdown/DropdownSkeleton.svelte
+++ b/src/Dropdown/DropdownSkeleton.svelte
@@ -3,6 +3,7 @@
   export let inline = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--skeleton="{true}"
   class:bx--dropdown-v2="{true}"

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -76,6 +76,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/FileUploader/FileUploaderItem.svelte
+++ b/src/FileUploader/FileUploaderItem.svelte
@@ -39,6 +39,7 @@
   const dispatch = createEventDispatcher();
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <span
   id="{id}"
   class:bx--file__selected-file="{true}"

--- a/src/FileUploader/FileUploaderSkeleton.svelte
+++ b/src/FileUploader/FileUploaderSkeleton.svelte
@@ -3,6 +3,7 @@
   import { SkeletonText } from "../SkeletonText";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Form/Form.svelte
+++ b/src/Form/Form.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <form
   class:bx--form="{true}"
   {...$$restProps}

--- a/src/FormGroup/FormGroup.svelte
+++ b/src/FormGroup/FormGroup.svelte
@@ -18,6 +18,7 @@
   export let legendId = "";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <fieldset
   data-invalid="{invalid || undefined}"
   class:bx--fieldset="{true}"

--- a/src/FormItem/FormItem.svelte
+++ b/src/FormItem/FormItem.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/FormLabel/FormLabel.svelte
+++ b/src/FormLabel/FormLabel.svelte
@@ -3,6 +3,7 @@
   export let id = "ccs-" + Math.random().toString(36);
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <label
   class:bx--label="{true}"
   for="{id}"

--- a/src/Icon/IconSkeleton.svelte
+++ b/src/Icon/IconSkeleton.svelte
@@ -8,6 +8,7 @@
   export let size = 16;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--icon--skeleton="{true}"
   {...$$restProps}

--- a/src/InlineLoading/InlineLoading.svelte
+++ b/src/InlineLoading/InlineLoading.svelte
@@ -44,6 +44,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--inline-loading="{true}"
   aria-live="assertive"

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -31,6 +31,7 @@
   export let ref = null;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if disabled}
   <p
     bind:this="{ref}"

--- a/src/ListItem/ListItem.svelte
+++ b/src/ListItem/ListItem.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <li
   class:bx--list__item="{true}"
   {...$$restProps}

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -136,6 +136,7 @@
   }
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   bind:this="{ref}"
   role="presentation"

--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -56,6 +56,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if open}
   <div
     role="{role}"

--- a/src/Notification/NotificationButton.svelte
+++ b/src/Notification/NotificationButton.svelte
@@ -23,6 +23,7 @@
   import Close20 from "carbon-icons-svelte/lib/Close20/Close20.svelte";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <button
   type="button"
   aria-label="{iconDescription}"

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -59,6 +59,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if open}
   <div
     role="{role}"

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -143,6 +143,7 @@
     "Numeric input field with increment and decrement buttons";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   on:click

--- a/src/NumberInput/NumberInputSkeleton.svelte
+++ b/src/NumberInput/NumberInputSkeleton.svelte
@@ -3,6 +3,7 @@
   export let hideLabel = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/OrderedList/OrderedList.svelte
+++ b/src/OrderedList/OrderedList.svelte
@@ -9,6 +9,7 @@
   export let expressive = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <ol
   class:bx--list--ordered="{!native}"
   class:bx--list--ordered--native="{native}"

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -174,6 +174,7 @@
   }}"
 />
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <button
   bind:this="{buttonRef}"
   type="button"

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -64,8 +64,6 @@
   import OverflowMenuVertical16 from "carbon-icons-svelte/lib/OverflowMenuVertical16/OverflowMenuVertical16.svelte";
   import OverflowMenuHorizontal16 from "carbon-icons-svelte/lib/OverflowMenuHorizontal16/OverflowMenuHorizontal16.svelte";
 
-  import { formatStyle } from "./formatStyle";
-
   const ctxBreadcrumbItem = getContext("BreadcrumbItem");
   const dispatch = createEventDispatcher();
   const items = writable([]);
@@ -155,10 +153,11 @@
   $: if ($items[$currentIndex]) {
     focusedId.set($items[$currentIndex].id);
   }
-  $: dynamicPseudoWidth = `#${id} .bx--overflow-menu-options.bx--overflow-menu-options:after {
+  $: styles = `<style>
+    #${id} .bx--overflow-menu-options.bx--overflow-menu-options:after {
       width: ${buttonWidth ? buttonWidth + "px" : "2rem"};
-    }`;
-  $: styles = formatStyle(dynamicPseudoWidth);
+    }
+  <\/style>`;
 </script>
 
 <svelte:head>

--- a/src/OverflowMenu/formatStyle.js
+++ b/src/OverflowMenu/formatStyle.js
@@ -1,1 +1,0 @@
-export const formatStyle = (style) => ["<style>", style, "</style>"].join("");

--- a/src/Pagination/PaginationSkeleton.svelte
+++ b/src/Pagination/PaginationSkeleton.svelte
@@ -2,6 +2,7 @@
   import SkeletonText from "../SkeletonText/SkeletonText.svelte";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--pagination="{true}"
   class:bx--skeleton="{true}"

--- a/src/ProgressIndicator/ProgressIndicator.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.svelte
@@ -60,6 +60,7 @@
   );
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <ul
   class:bx--progress="{true}"
   class:bx--progress--vertical="{vertical}"

--- a/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
+++ b/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
@@ -6,6 +6,7 @@
   export let count = 4;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <ul
   class:bx--progress="{true}"
   class:bx--progress--vertical="{vertical}"

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -48,6 +48,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <li
   aria-disabled="{disabled}"
   id="{id}"

--- a/src/RadioButton/RadioButtonSkeleton.svelte
+++ b/src/RadioButton/RadioButtonSkeleton.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--radio-button-wrapper="{true}"
   {...$$restProps}

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -66,6 +66,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   id="{id}"
   class:bx--form-item="{true}"

--- a/src/Search/SearchSkeleton.svelte
+++ b/src/Search/SearchSkeleton.svelte
@@ -12,6 +12,7 @@
   export let size = "xl";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--skeleton="{true}"
   class:bx--search--sm="{size === 'sm' || small}"

--- a/src/Select/SelectSkeleton.svelte
+++ b/src/Select/SelectSkeleton.svelte
@@ -3,6 +3,7 @@
   export let hideLabel = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte
+++ b/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--skeleton__placeholder="{true}"
   {...$$restProps}

--- a/src/SkeletonText/SkeletonText.svelte
+++ b/src/SkeletonText/SkeletonText.svelte
@@ -26,6 +26,7 @@
   }
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if paragraph}
   <div {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
     {#each rows as { width }}

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -124,6 +124,7 @@
   on:touchcancel="{stopHolding}"
 />
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Slider/SliderSkeleton.svelte
+++ b/src/Slider/SliderSkeleton.svelte
@@ -3,6 +3,7 @@
   export let hideLabel = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -37,6 +37,7 @@
   $: dispatch("change", $selectedValue);
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   role="table"
   class:bx--structured-list="{true}"

--- a/src/StructuredList/StructuredListBody.svelte
+++ b/src/StructuredList/StructuredListBody.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   role="rowgroup"
   class:bx--structured-list-tbody="{true}"

--- a/src/StructuredList/StructuredListCell.svelte
+++ b/src/StructuredList/StructuredListCell.svelte
@@ -6,6 +6,7 @@
   export let noWrap = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   role="{head ? 'columnheader' : 'cell'}"
   class:bx--structured-list-th="{head}"

--- a/src/StructuredList/StructuredListHead.svelte
+++ b/src/StructuredList/StructuredListHead.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   role="rowgroup"
   class:bx--structured-list-thead="{true}"

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -9,6 +9,7 @@
   export let tabindex = "0";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if label}
   <!-- svelte-ignore a11y-label-has-associated-control -->
   <label

--- a/src/StructuredList/StructuredListSkeleton.svelte
+++ b/src/StructuredList/StructuredListSkeleton.svelte
@@ -6,6 +6,7 @@
   export let border = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--skeleton="{true}"
   class:bx--structured-list="{true}"

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -43,6 +43,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <li
   tabindex="-1"
   role="presentation"

--- a/src/Tabs/TabsSkeleton.svelte
+++ b/src/Tabs/TabsSkeleton.svelte
@@ -9,6 +9,7 @@
   export let type = "default";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--tabs="{true}"
   class:bx--skeleton="{true}"

--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -41,6 +41,7 @@
   const dispatch = createEventDispatcher();
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if skeleton}
   <TagSkeleton
     size="{size}"

--- a/src/Tag/TagSkeleton.svelte
+++ b/src/Tag/TagSkeleton.svelte
@@ -3,6 +3,7 @@
   export let size = "default";
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <span
   class:bx--tag="{true}"
   class:bx--tag--sm="{size === 'sm'}"

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -49,6 +49,7 @@
   $: errorId = `error-${id}`;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   on:click
   on:mouseover

--- a/src/TextArea/TextAreaSkeleton.svelte
+++ b/src/TextArea/TextAreaSkeleton.svelte
@@ -3,6 +3,7 @@
   export let hideLabel = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -93,6 +93,7 @@
   $: warnId = `warn-${id}`;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   class:bx--text-input-wrapper="{true}"

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -77,6 +77,7 @@
   $: warnId = `warn-${id}`;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   class:bx--text-input-wrapper="{true}"

--- a/src/TextInput/TextInputSkeleton.svelte
+++ b/src/TextInput/TextInputSkeleton.svelte
@@ -3,6 +3,7 @@
   export let hideLabel = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -51,6 +51,7 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <button
   bind:this="{ref}"
   type="button"

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -56,6 +56,7 @@
     }
   }}"
 />
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <label
   for="{id}"
   class:bx--tile="{true}"

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -52,6 +52,7 @@
   title="{title}"
   disabled="{disabled}"
 />
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <label
   for="{id}"
   tabindex="{disabled ? undefined : tabindex}"

--- a/src/Tile/Tile.svelte
+++ b/src/Tile/Tile.svelte
@@ -3,6 +3,7 @@
   export let light = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--tile="{true}"
   class:bx--tile--light="{light}"

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -57,6 +57,7 @@
   export let ref = null;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   on:click

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -44,6 +44,7 @@
   $: value = $selectedValue;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--select="{true}"
   class:bx--time-picker__select="{true}"

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -40,6 +40,7 @@
   $: dispatch("toggle", { toggled });
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Toggle/ToggleSkeleton.svelte
+++ b/src/Toggle/ToggleSkeleton.svelte
@@ -12,6 +12,7 @@
   export let id = "ccs-" + Math.random().toString(36);
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/ToggleSmall/ToggleSmall.svelte
+++ b/src/ToggleSmall/ToggleSmall.svelte
@@ -30,6 +30,7 @@
   export let name = undefined;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/ToggleSmall/ToggleSmallSkeleton.svelte
+++ b/src/ToggleSmall/ToggleSmallSkeleton.svelte
@@ -12,6 +12,7 @@
   export let id = "ccs-" + Math.random().toString(36);
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/UnorderedList/UnorderedList.svelte
+++ b/src/UnorderedList/UnorderedList.svelte
@@ -6,6 +6,7 @@
   export let expressive = false;
 </script>
 
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <ul
   class:bx--list--unordered="{true}"
   class:bx--list--nested="{nested}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,10 +463,10 @@ carbon-components@10.40.0:
     lodash.debounce "^4.0.8"
     warning "^3.0.0"
 
-carbon-icons-svelte@^10.27.0:
-  version "10.27.0"
-  resolved "https://registry.yarnpkg.com/carbon-icons-svelte/-/carbon-icons-svelte-10.27.0.tgz#918e806d09e0e9cf61cf756ff0f9be49125ff9ea"
-  integrity sha512-e3l95wurOuEYMQxaDT2oYH322yRKgvTq5TDkzvylMGlCkA8erJH5lSwCM59VNFgPtptH4fIW9FlbQtpfp4iQ7Q==
+carbon-icons-svelte@^10.36.0:
+  version "10.36.0"
+  resolved "https://registry.yarnpkg.com/carbon-icons-svelte/-/carbon-icons-svelte-10.36.0.tgz#3f269f2c52520d14fcd42161a633afbb7c68b4bf"
+  integrity sha512-YlrHtjdRqMFiptNVpQ4M+gMvpYDoKQydBY5A82thAXIHk9JrbrVLzq6RgJugTijHT8yzMS1zXaw6YYhqL8Qzqw==
 
 chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,10 +2434,15 @@ svelte-preprocess@^4.7.3:
     detect-indent "^6.0.0"
     strip-indent "^3.0.0"
 
-svelte@^3.31.2, svelte@^3.32.1:
+svelte@^3.31.2:
   version "3.32.1"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.32.1.tgz#c4b6e35517d0ed77e652cc8964ef660afa2f70f3"
   integrity sha512-j1KmD2ZOU0RGq1/STDXjwfh0/eJ/Deh2NXyuz1bpR9eOcz9yImn4CGxXdbSAN7cMTm9a7IyPUIbuBCzu/pXK0g==
+
+svelte@^3.40.1:
+  version "3.40.1"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.40.1.tgz#0c1fa443c812f042ce5ccd8d3bec1654a612c259"
+  integrity sha512-IreCwsCD5yoKlXCDXCyHZ0mh1wNwm3/5QD+nVNBzSWug5dUiWcah/8QWnDcC3IYbJbn0ZRT04b8y4ITMtr1bNQ==
 
 terser@^5.0.0:
   version "5.3.0"


### PR DESCRIPTION
**Fixes**

- disable `a11y-mouse-events-have-key-events` warnings
- upgrade `carbon-icons-svelte` to v10.36.0 to quell `a11y-mouse...` warnings

**Refactor**

- remove `formatStyle` utility in `OverflowMenu`

**Documentation**

- add `svelte:head` example usage for loading CDN styles
- add instructions for dynamic theming
- update number of available Carbon icons